### PR TITLE
Refactor/commands

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,37 @@
+## Summary
+
+Adds `init` command that initializes new projects with interactive scaffolding, allowing choice between frameworks (Next.js/Elysia), linters (ESLint/Biome), and optional BetterAuth configuration.
+
+## Related Issue
+
+Closes (N/A)
+
+## Why
+
+The CLI needed a simple way to create new projects integrated with AbacatePay. Before, developers had to manually clone templates and configure everything by hand. The `init` command automates this entire process with an interactive onboarding flow.
+
+## What changed
+
+- Created `cmd/init.go` with interactive onboarding flow using prompts from the `style` package
+- Created `internal/scaffold/config.go` with `Config` structure and validation methods
+- Created `internal/scaffold/git.go` for repository clone operations
+- Created `internal/scaffold/package.go` for `package.json` manipulation and merging
+- Created `internal/scaffold/fs.go` for file and directory copy operations
+- Created `internal/scaffold/scaffold.go` with scaffolding orchestration via `ProjectBuilder`
+- Implemented layer-based composition system that combines base templates + linters + features (BetterAuth)
+
+## Breaking changes
+
+- [ ] Yes
+- [X] No
+
+## Checklist
+
+- [ ] Docs updated
+- [X] CI passing
+- [X] I followed the CONTRIBUTING guidelines
+- [X] I added or updated tests (if applicable)
+
+## Additional context
+
+The command uses the `github.com/albuquerquesz/abacatepay-templates` repository as the source for templates. The layer-based composition architecture allows adding new frameworks, linters, and features without creating a combinatorial explosion of templates.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"fmt"
+
+	"abacatepay-cli/internal/style"
+
+	"github.com/spf13/cobra"
+)
+
+type projectConfig struct {
+	Name       string
+	Framework  string
+	Linter     string
+	BetterAuth bool
+}
+
+var initCmd = &cobra.Command{
+	Use:   "init [project-name]",
+	Short: "Initialize a new AbacatePay project",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var name string
+		if len(args) > 0 {
+			name = args[0]
+		}
+		return initializeProject(name)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}
+
+func initializeProject(name string) error {
+	cfg := projectConfig{}
+
+	if name != "" {
+		cfg.Name = name
+	} else {
+		if err := style.Input("Project name", "my-app", &cfg.Name, func(s string) error {
+			if s == "" {
+				return fmt.Errorf("project name is required")
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+
+	frameworkOptions := map[string]string{
+		"Next.js": "nextjs",
+		"Elysia":  "elysia",
+	}
+	framework, err := style.Select("Which framework do you want to use?", frameworkOptions)
+	if err != nil {
+		return err
+	}
+	cfg.Framework = framework
+
+	linterOptions := map[string]string{
+		"ESLint": "eslint",
+		"Biome":  "biome",
+	}
+	linter, err := style.Select("Which linter do you want to use?", linterOptions)
+	if err != nil {
+		return err
+	}
+	cfg.Linter = linter
+
+	if err := style.Confirm("Do you want BetterAuth already configured?", &cfg.BetterAuth); err != nil {
+		return err
+	}
+
+	betterAuthLabel := "No"
+	if cfg.BetterAuth {
+		betterAuthLabel = "Yes"
+	}
+
+	frameworkLabel := "Next.js"
+	if cfg.Framework == "elysia" {
+		frameworkLabel = "Elysia"
+	}
+
+	linterLabel := "ESLint"
+	if cfg.Linter == "biome" {
+		linterLabel = "Biome"
+	}
+
+	style.PrintSuccess("Project configured!", map[string]string{
+		"Name":       cfg.Name,
+		"Framework":  frameworkLabel,
+		"Linter":     linterLabel,
+		"BetterAuth": betterAuthLabel,
+	})
+
+	return nil
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -46,7 +46,6 @@ func initializeProject(name string) error {
 		}
 	}
 
-	// Validate project name
 	if err := scaffold.ValidateProjectName(cfg.Name); err != nil {
 		return err
 	}
@@ -75,7 +74,6 @@ func initializeProject(name string) error {
 		return err
 	}
 
-	// Show configuration summary
 	betterAuthLabel := "No"
 	if cfg.BetterAuth {
 		betterAuthLabel = "Yes"
@@ -98,7 +96,6 @@ func initializeProject(name string) error {
 		"BetterAuth": betterAuthLabel,
 	})
 
-	// Scaffold the project
 	fmt.Printf("\n🥑 Creating project %s...\n\n", cfg.Name)
 
 	scaffoldCfg := scaffold.Config{
@@ -112,8 +109,7 @@ func initializeProject(name string) error {
 		return fmt.Errorf("failed to scaffold project: %w", err)
 	}
 
-	// Show next steps
-	fmt.Println("✅ Project created successfully!\n")
+	fmt.Println("✅ Project created successfully!")
 	fmt.Println("Next steps:")
 
 	steps := scaffoldCfg.GetNextSteps()

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -116,7 +116,7 @@ func initializeProject(name string) error {
 	fmt.Println("✅ Project created successfully!\n")
 	fmt.Println("Next steps:")
 
-	steps := scaffold.GetNextSteps(scaffoldCfg)
+	steps := scaffoldCfg.GetNextSteps()
 	for _, step := range steps {
 		fmt.Printf("  %s\n", step)
 	}

--- a/internal/scaffold/config.go
+++ b/internal/scaffold/config.go
@@ -1,0 +1,68 @@
+// Package scaffold provides project scaffolding functionality for AbacatePay CLI.
+// It handles cloning templates, composing project layers, and setting up new projects.
+package scaffold
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Config holds the scaffold configuration for creating a new project.
+type Config struct {
+	ProjectName string // Name of the project (directory name)
+	Framework   string // Framework to use: "next" or "elysia"
+	Linter      string // Linter to use: "eslint" or "biome"
+	BetterAuth  bool   // Whether to include BetterAuth configuration
+}
+
+// Validate checks if the configuration is valid.
+func (c Config) Validate() error {
+	if err := ValidateProjectName(c.ProjectName); err != nil {
+		return err
+	}
+
+	validFrameworks := map[string]bool{"next": true, "elysia": true}
+	if !validFrameworks[c.Framework] {
+		return fmt.Errorf("invalid framework: %s (must be 'next' or 'elysia')", c.Framework)
+	}
+
+	validLinters := map[string]bool{"eslint": true, "biome": true}
+	if !validLinters[c.Linter] {
+		return fmt.Errorf("invalid linter: %s (must be 'eslint' or 'biome')", c.Linter)
+	}
+
+	return nil
+}
+
+// ValidateProjectName checks if the project name is valid.
+// It ensures the name is not empty and doesn't contain invalid characters.
+func ValidateProjectName(name string) error {
+	if name == "" {
+		return fmt.Errorf("project name is required")
+	}
+
+	// Check for invalid characters that are not allowed in directory names
+	invalidChars := []string{"/", "\\", ":", "*", "?", "\"", "<", ">", "|"}
+	for _, char := range invalidChars {
+		if strings.Contains(name, char) {
+			return fmt.Errorf("project name cannot contain '%s'", char)
+		}
+	}
+
+	return nil
+}
+
+// GetNextSteps returns the list of commands the user should run after project creation.
+func (c Config) GetNextSteps() []string {
+	steps := []string{
+		fmt.Sprintf("cd %s", c.ProjectName),
+		"bun install",
+		"cp .env.example .env",
+	}
+
+	// Both frameworks use the same commands for now
+	steps = append(steps, "bun run db:push")
+	steps = append(steps, "bun run dev")
+
+	return steps
+}

--- a/internal/scaffold/fs.go
+++ b/internal/scaffold/fs.go
@@ -1,0 +1,81 @@
+package scaffold
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// CopyFile copies a single file from src to dst.
+// It creates parent directories as needed.
+func CopyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file %s: %w", src, err)
+	}
+	defer srcFile.Close()
+
+	// Ensure parent directory exists
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("failed to create directory for %s: %w", dst, err)
+	}
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file %s: %w", dst, err)
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("failed to copy file %s to %s: %w", src, dst, err)
+	}
+
+	return nil
+}
+
+// CopyDir recursively copies a directory from src to dst.
+// It skips node_modules and .git directories.
+func CopyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip node_modules and .git directories
+		if info.IsDir() && (info.Name() == "node_modules" || info.Name() == ".git") {
+			return filepath.SkipDir
+		}
+
+		// Calculate relative path
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return fmt.Errorf("failed to calculate relative path: %w", err)
+		}
+
+		dstPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+
+		return CopyFile(path, dstPath)
+	})
+}
+
+// EnsureDir creates a directory if it doesn't exist.
+func EnsureDir(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+// DirExists checks if a directory exists.
+func DirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// FileExists checks if a file exists.
+func FileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/scaffold/fs.go
+++ b/internal/scaffold/fs.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 )
 
-// CopyFile copies a single file from src to dst.
-// It creates parent directories as needed.
 func CopyFile(src, dst string) error {
 	srcFile, err := os.Open(src)
 	if err != nil {
@@ -16,8 +14,8 @@ func CopyFile(src, dst string) error {
 	}
 	defer srcFile.Close()
 
-	// Ensure parent directory exists
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+	err = os.MkdirAll(filepath.Dir(dst), 0o755)
+	if err != nil {
 		return fmt.Errorf("failed to create directory for %s: %w", dst, err)
 	}
 
@@ -34,20 +32,16 @@ func CopyFile(src, dst string) error {
 	return nil
 }
 
-// CopyDir recursively copies a directory from src to dst.
-// It skips node_modules and .git directories.
 func CopyDir(src, dst string) error {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		// Skip node_modules and .git directories
 		if info.IsDir() && (info.Name() == "node_modules" || info.Name() == ".git") {
 			return filepath.SkipDir
 		}
 
-		// Calculate relative path
 		relPath, err := filepath.Rel(src, path)
 		if err != nil {
 			return fmt.Errorf("failed to calculate relative path: %w", err)
@@ -63,18 +57,15 @@ func CopyDir(src, dst string) error {
 	})
 }
 
-// EnsureDir creates a directory if it doesn't exist.
 func EnsureDir(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)
 }
 
-// DirExists checks if a directory exists.
 func DirExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.IsDir()
 }
 
-// FileExists checks if a file exists.
 func FileExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()

--- a/internal/scaffold/git.go
+++ b/internal/scaffold/git.go
@@ -1,0 +1,24 @@
+package scaffold
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// GitRepositoryURL is the URL of the templates repository.
+const GitRepositoryURL = "https://github.com/AbacatePay/templates.git"
+
+// GitClone clones the templates repository into the specified directory.
+// It performs a shallow clone (--depth 1) to save bandwidth and time.
+func GitClone(destDir string) error {
+	cmd := exec.Command("git", "clone", "--depth", "1", GitRepositoryURL, destDir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git clone failed: %w", err)
+	}
+
+	return nil
+}

--- a/internal/scaffold/git.go
+++ b/internal/scaffold/git.go
@@ -7,7 +7,7 @@ import (
 )
 
 // GitRepositoryURL is the URL of the templates repository.
-const GitRepositoryURL = "https://github.com/AbacatePay/templates.git"
+const GitRepositoryURL = "https://github.com/albuquerquesz/abacatepay-templates.git"
 
 // GitClone clones the templates repository into the specified directory.
 // It performs a shallow clone (--depth 1) to save bandwidth and time.

--- a/internal/scaffold/package.go
+++ b/internal/scaffold/package.go
@@ -1,0 +1,117 @@
+package scaffold
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+)
+
+// PackageJSON represents the structure of a package.json file.
+type PackageJSON struct {
+	Name            string            `json:"name"`
+	Version         string            `json:"version"`
+	Private         bool              `json:"private,omitempty"`
+	Scripts         map[string]string `json:"scripts,omitempty"`
+	Dependencies    map[string]string `json:"dependencies,omitempty"`
+	DevDependencies map[string]string `json:"devDependencies,omitempty"`
+}
+
+// ReadPackageJSON reads and parses a package.json file from the given path.
+func ReadPackageJSON(path string) (*PackageJSON, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read package.json: %w", err)
+	}
+
+	var pkg PackageJSON
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, fmt.Errorf("failed to parse package.json: %w", err)
+	}
+
+	return &pkg, nil
+}
+
+// Write writes the package.json to the specified path.
+func (p *PackageJSON) Write(path string) error {
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal package.json: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write package.json: %w", err)
+	}
+
+	return nil
+}
+
+// MergeDependencies merges dependencies from another package.json into this one.
+// The source dependencies will be added to the destination, overwriting any existing ones.
+func (p *PackageJSON) MergeDependencies(source *PackageJSON) {
+	if source.Dependencies != nil {
+		if p.Dependencies == nil {
+			p.Dependencies = make(map[string]string)
+		}
+		maps.Copy(p.Dependencies, source.Dependencies)
+	}
+
+	if source.DevDependencies != nil {
+		if p.DevDependencies == nil {
+			p.DevDependencies = make(map[string]string)
+		}
+		maps.Copy(p.DevDependencies, source.DevDependencies)
+	}
+}
+
+// MergeScripts merges scripts from another package.json into this one.
+func (p *PackageJSON) MergeScripts(source *PackageJSON) {
+	if source.Scripts != nil {
+		if p.Scripts == nil {
+			p.Scripts = make(map[string]string)
+		}
+		maps.Copy(p.Scripts, source.Scripts)
+	}
+}
+
+// LoadAndMerge reads a package.json file and merges its contents into this one.
+func (p *PackageJSON) LoadAndMerge(path string) error {
+	source, err := ReadPackageJSON(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // File doesn't exist, nothing to merge
+		}
+		return err
+	}
+
+	p.MergeDependencies(source)
+	p.MergeScripts(source)
+	return nil
+}
+
+// LoadScriptsAndMerge reads a scripts.json file and merges its scripts into this package.json.
+func (p *PackageJSON) LoadScriptsAndMerge(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // File doesn't exist, nothing to merge
+		}
+		return fmt.Errorf("failed to read scripts file: %w", err)
+	}
+
+	var scriptsWrapper struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &scriptsWrapper); err != nil {
+		return fmt.Errorf("failed to parse scripts file: %w", err)
+	}
+
+	if scriptsWrapper.Scripts != nil {
+		if p.Scripts == nil {
+			p.Scripts = make(map[string]string)
+		}
+		maps.Copy(p.Scripts, scriptsWrapper.Scripts)
+	}
+
+	return nil
+}

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -159,7 +159,6 @@ func mergePackageJSONs(projectPath, templatesDir, framework, linter string, bett
 		}
 	}
 
-	// Write merged package.json
 	if err := writePackageJSON(mainPackagePath, mainPkg); err != nil {
 		return err
 	}
@@ -167,14 +166,13 @@ func mergePackageJSONs(projectPath, templatesDir, framework, linter string, bett
 	return nil
 }
 
-// readPackageJSON reads and parses a package.json file
-func readPackageJSON(path string) (map[string]interface{}, error) {
+func readPackageJSON(path string) (map[string]any, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	var pkg map[string]interface{}
+	var pkg map[string]any
 	if err := json.Unmarshal(data, &pkg); err != nil {
 		return nil, err
 	}
@@ -182,8 +180,7 @@ func readPackageJSON(path string) (map[string]interface{}, error) {
 	return pkg, nil
 }
 
-// mergePackageJSON merges a package.json file into the main package
-func mergePackageJSON(main map[string]interface{}, mergePath string) error {
+func mergePackageJSON(main map[string]any, mergePath string) error {
 	data, err := os.ReadFile(mergePath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -192,38 +189,31 @@ func mergePackageJSON(main map[string]interface{}, mergePath string) error {
 		return err
 	}
 
-	var merge map[string]interface{}
+	var merge map[string]any
 	if err := json.Unmarshal(data, &merge); err != nil {
 		return err
 	}
 
-	// Merge dependencies
-	if deps, ok := merge["dependencies"].(map[string]interface{}); ok {
+	if deps, ok := merge["dependencies"].(map[string]any); ok {
 		if main["dependencies"] == nil {
-			main["dependencies"] = make(map[string]interface{})
+			main["dependencies"] = make(map[string]any)
 		}
-		mainDeps := main["dependencies"].(map[string]interface{})
-		for k, v := range deps {
-			mainDeps[k] = v
-		}
+		mainDeps := main["dependencies"].(map[string]any)
+		maps.Copy(deps, mainDeps)
 	}
 
-	// Merge devDependencies
-	if devDeps, ok := merge["devDependencies"].(map[string]interface{}); ok {
+	if devDeps, ok := merge["devDependencies"].(map[string]any); ok {
 		if main["devDependencies"] == nil {
-			main["devDependencies"] = make(map[string]interface{})
+			main["devDependencies"] = make(map[string]any)
 		}
-		mainDevDeps := main["devDependencies"].(map[string]interface{})
-		for k, v := range devDeps {
-			mainDevDeps[k] = v
-		}
+		mainDevDeps := main["devDependencies"].(map[string]any)
+		maps.Copy(devDeps, mainDevDeps)
 	}
 
 	return nil
 }
 
-// mergeScripts merges scripts from a scripts.json file
-func mergeScripts(main map[string]interface{}, scriptsPath string) error {
+func mergeScripts(main map[string]any, scriptsPath string) error {
 	data, err := os.ReadFile(scriptsPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -1,321 +1,215 @@
 package scaffold
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"maps"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 )
 
-type Config struct {
-	ProjectName string
-	Framework   string
-	Linter      string
-	BetterAuth  bool
+const templatesRepoURL = "https://github.com/AbacatePay/templates.git"
+
+// ProjectBuilder handles the construction of a new project by composing template layers.
+type ProjectBuilder struct {
+	config       Config
+	templatesDir string
+	projectPath  string
 }
 
-func ScaffoldProject(cfg Config, targetDir string) error {
+// NewProjectBuilder creates a new ProjectBuilder instance.
+func NewProjectBuilder(cfg Config, targetDir string) (*ProjectBuilder, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &ProjectBuilder{
+		config:      cfg,
+		projectPath: filepath.Join(targetDir, cfg.ProjectName),
+	}, nil
+}
+
+// Build executes the complete project scaffolding process.
+// It clones templates, applies layers, and finalizes the project.
+func (pb *ProjectBuilder) Build() error {
+	// Create temporary directory for templates
 	tempDir, err := os.MkdirTemp("", "abacate-templates-*")
 	if err != nil {
 		return fmt.Errorf("failed to create temp directory: %w", err)
 	}
 	defer os.RemoveAll(tempDir)
 
-	if err := cloneTemplates(tempDir); err != nil {
-		return fmt.Errorf("failed to clone templates: %w", err)
+	// Clone templates repository
+	if err := pb.cloneTemplates(tempDir); err != nil {
+		return err
 	}
 
-	templatesDir := filepath.Join(tempDir, "templates")
+	pb.templatesDir = filepath.Join(tempDir, "templates")
 
-	projectPath := filepath.Join(targetDir, cfg.ProjectName)
-	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+	// Create project directory
+	if err := EnsureDir(pb.projectPath, 0o755); err != nil {
 		return fmt.Errorf("failed to create project directory: %w", err)
 	}
 
-	basePath := filepath.Join(templatesDir, "base", cfg.Framework)
-	if err := copyDir(basePath, projectPath); err != nil {
+	// Apply template layers
+	if err := pb.applyBaseTemplate(); err != nil {
+		return err
+	}
+
+	if err := pb.applyLinter(); err != nil {
+		return err
+	}
+
+	if err := pb.applyFeatures(); err != nil {
+		return err
+	}
+
+	if err := pb.finalizePackageJSON(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// cloneTemplates clones the templates repository into the temp directory.
+func (pb *ProjectBuilder) cloneTemplates(tempDir string) error {
+	if err := GitClone(tempDir); err != nil {
+		return fmt.Errorf("failed to clone templates repository: %w", err)
+	}
+	return nil
+}
+
+// applyBaseTemplate copies the base template for the selected framework.
+func (pb *ProjectBuilder) applyBaseTemplate() error {
+	basePath := filepath.Join(pb.templatesDir, "base", pb.config.Framework)
+
+	if !DirExists(basePath) {
+		return fmt.Errorf("base template not found for framework: %s", pb.config.Framework)
+	}
+
+	if err := CopyDir(basePath, pb.projectPath); err != nil {
 		return fmt.Errorf("failed to copy base template: %w", err)
 	}
 
-	if err := applyLinter(templatesDir, cfg.Framework, cfg.Linter, projectPath); err != nil {
-		return fmt.Errorf("failed to apply linter: %w", err)
-	}
-
-	if cfg.BetterAuth {
-		if err := applyBetterAuth(templatesDir, cfg.Framework, projectPath); err != nil {
-			return fmt.Errorf("failed to apply better-auth: %w", err)
-		}
-	}
-
-	if err := mergePackageJSONs(projectPath, templatesDir, cfg.Framework, cfg.Linter, cfg.BetterAuth); err != nil {
-		return fmt.Errorf("failed to merge package.json: %w", err)
-	}
-
-	if err := updateProjectName(projectPath, cfg.ProjectName); err != nil {
-		return fmt.Errorf("failed to update project name: %w", err)
-	}
-
 	return nil
 }
 
-func cloneTemplates(destDir string) error {
-	repoURL := "https://github.com/AbacatePay/templates.git"
+// applyLinter applies the selected linter configuration to the project.
+func (pb *ProjectBuilder) applyLinter() error {
+	linterDir := filepath.Join(pb.templatesDir, "linters", pb.config.Linter)
 
-	cmd := exec.Command("git", "clone", "--depth", "1", repoURL, destDir)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func applyLinter(templatesDir, framework, linter, projectPath string) error {
-	linterDir := filepath.Join(templatesDir, "linters", linter)
-
-	var configFile string
-
-	switch linter {
+	switch pb.config.Linter {
 	case "eslint":
-		if framework == "next" {
-			configFile = "eslint.config.next.js"
-		} else {
-			configFile = "eslint.config.elysia.js"
-		}
-		if err := copyFile(
-			filepath.Join(linterDir, configFile),
-			filepath.Join(projectPath, "eslint.config.js"),
-		); err != nil {
+		if err := pb.applyESLint(linterDir); err != nil {
 			return err
 		}
 	case "biome":
-		if err := copyFile(
-			filepath.Join(linterDir, "biome.json"),
-			filepath.Join(projectPath, "biome.json"),
-		); err != nil {
-			return err
-		}
-
-	}
-
-	return nil
-}
-
-func applyBetterAuth(templatesDir, framework, projectPath string) error {
-	authDir := filepath.Join(templatesDir, "features", "betterauth", framework)
-
-	if err := copyDir(authDir, projectPath); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func mergePackageJSONs(projectPath, templatesDir, framework, linter string, betterAuth bool) error {
-	mainPackagePath := filepath.Join(projectPath, "package.json")
-
-	mainPkg, err := readPackageJSON(mainPackagePath)
-	if err != nil {
-		return err
-	}
-
-	linterPackagePath := filepath.Join(templatesDir, "linters", linter, "package.json")
-	if err := mergePackageJSON(mainPkg, linterPackagePath); err != nil {
-		return err
-	}
-
-	linterScriptsPath := filepath.Join(templatesDir, "linters", linter, "scripts.json")
-	if err := mergeScripts(mainPkg, linterScriptsPath); err != nil {
-		return err
-	}
-
-	if betterAuth {
-		authPackagePath := filepath.Join(templatesDir, "features", "betterauth", framework, "package.json")
-		if err := mergePackageJSON(mainPkg, authPackagePath); err != nil {
+		if err := pb.applyBiome(linterDir); err != nil {
 			return err
 		}
 	}
 
-	if err := writePackageJSON(mainPackagePath, mainPkg); err != nil {
-		return err
+	return nil
+}
+
+// applyESLint copies the ESLint configuration file.
+func (pb *ProjectBuilder) applyESLint(linterDir string) error {
+	configFile := "eslint.config.elysia.js"
+	if pb.config.Framework == "next" {
+		configFile = "eslint.config.next.js"
+	}
+
+	src := filepath.Join(linterDir, configFile)
+	dst := filepath.Join(pb.projectPath, "eslint.config.js")
+
+	if err := CopyFile(src, dst); err != nil {
+		return fmt.Errorf("failed to copy ESLint config: %w", err)
 	}
 
 	return nil
 }
 
-func readPackageJSON(path string) (map[string]any, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
+// applyBiome copies the Biome configuration file.
+func (pb *ProjectBuilder) applyBiome(linterDir string) error {
+	src := filepath.Join(linterDir, "biome.json")
+	dst := filepath.Join(pb.projectPath, "biome.json")
 
-	var pkg map[string]any
-	if err := json.Unmarshal(data, &pkg); err != nil {
-		return nil, err
-	}
-
-	return pkg, nil
-}
-
-func mergePackageJSON(main map[string]any, mergePath string) error {
-	data, err := os.ReadFile(mergePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	var merge map[string]any
-	if err := json.Unmarshal(data, &merge); err != nil {
-		return err
-	}
-
-	if deps, ok := merge["dependencies"].(map[string]any); ok {
-		if main["dependencies"] == nil {
-			main["dependencies"] = make(map[string]any)
-		}
-		mainDeps := main["dependencies"].(map[string]any)
-		maps.Copy(deps, mainDeps)
-	}
-
-	if devDeps, ok := merge["devDependencies"].(map[string]any); ok {
-		if main["devDependencies"] == nil {
-			main["devDependencies"] = make(map[string]any)
-		}
-		mainDevDeps := main["devDependencies"].(map[string]any)
-		maps.Copy(devDeps, mainDevDeps)
+	if err := CopyFile(src, dst); err != nil {
+		return fmt.Errorf("failed to copy Biome config: %w", err)
 	}
 
 	return nil
 }
 
-func mergeScripts(main map[string]any, scriptsPath string) error {
-	data, err := os.ReadFile(scriptsPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	var scripts map[string]any
-	if err := json.Unmarshal(data, &scripts); err != nil {
-		return err
-	}
-
-	if scriptsMap, ok := scripts["scripts"].(map[string]any); ok {
-		if main["scripts"] == nil {
-			main["scripts"] = make(map[string]any)
-		}
-		mainScripts := main["scripts"].(map[string]any)
-		maps.Copy(mainScripts, scriptsMap)
-	}
-
-	return nil
-}
-
-func updateProjectName(projectPath, name string) error {
-	pkg, err := readPackageJSON(filepath.Join(projectPath, "package.json"))
-	if err != nil {
-		return err
-	}
-
-	pkg["name"] = name
-
-	return writePackageJSON(filepath.Join(projectPath, "package.json"), pkg)
-}
-
-func writePackageJSON(path string, pkg map[string]any) error {
-	data, err := json.MarshalIndent(pkg, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(path, data, 0o644)
-}
-
-func copyDir(src, dst string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
+// applyFeatures applies selected features (like BetterAuth) to the project.
+func (pb *ProjectBuilder) applyFeatures() error {
+	if pb.config.BetterAuth {
+		if err := pb.applyBetterAuth(); err != nil {
 			return err
 		}
-
-		if info.IsDir() && (info.Name() == "node_modules" || info.Name() == ".git") {
-			return filepath.SkipDir
-		}
-
-		relPath, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-
-		dstPath := filepath.Join(dst, relPath)
-
-		if info.IsDir() {
-			return os.MkdirAll(dstPath, info.Mode())
-		}
-
-		return copyFile(path, dstPath)
-	})
-}
-
-func copyFile(src, dst string) error {
-	srcFile, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer srcFile.Close()
-
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return err
-	}
-
-	dstFile, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer dstFile.Close()
-
-	_, err = io.Copy(dstFile, srcFile)
-	return err
-}
-
-func GetNextSteps(cfg Config) []string {
-	steps := []string{
-		fmt.Sprintf("cd %s", cfg.ProjectName),
-		"bun install",
-		"cp .env.example .env",
-	}
-
-	if cfg.Framework == "next" {
-		steps = append(steps, "bun run db:push")
-		steps = append(steps, "bun run dev")
-	} else {
-		steps = append(steps, "bun run db:push")
-		steps = append(steps, "bun run dev")
-	}
-
-	return steps
-}
-
-func ValidateProjectName(name string) error {
-	if name == "" {
-		return fmt.Errorf("project name is required")
-	}
-
-	invalidChars := []string{"/", "\\", ":", "*", "?", "\"", "<", ">", "|"}
-	for _, char := range invalidChars {
-		if strings.Contains(name, char) {
-			return fmt.Errorf("project name cannot contain '%s'", char)
-		}
 	}
 
 	return nil
+}
+
+// applyBetterAuth applies the BetterAuth feature to the project.
+func (pb *ProjectBuilder) applyBetterAuth() error {
+	authDir := filepath.Join(pb.templatesDir, "features", "betterauth", pb.config.Framework)
+
+	if !DirExists(authDir) {
+		return fmt.Errorf("betterauth template not found for framework: %s", pb.config.Framework)
+	}
+
+	if err := CopyDir(authDir, pb.projectPath); err != nil {
+		return fmt.Errorf("failed to copy better-auth files: %w", err)
+	}
+
+	return nil
+}
+
+// finalizePackageJSON merges all package.json fragments and updates the project name.
+func (pb *ProjectBuilder) finalizePackageJSON() error {
+	mainPackagePath := filepath.Join(pb.projectPath, "package.json")
+
+	// Read main package.json
+	pkg, err := ReadPackageJSON(mainPackagePath)
+	if err != nil {
+		return fmt.Errorf("failed to read package.json: %w", err)
+	}
+
+	// Merge linter dependencies and scripts
+	linterDir := filepath.Join(pb.templatesDir, "linters", pb.config.Linter)
+	if err := pkg.LoadAndMerge(filepath.Join(linterDir, "package.json")); err != nil {
+		return fmt.Errorf("failed to merge linter dependencies: %w", err)
+	}
+	if err := pkg.LoadScriptsAndMerge(filepath.Join(linterDir, "scripts.json")); err != nil {
+		return fmt.Errorf("failed to merge linter scripts: %w", err)
+	}
+
+	// Merge better-auth dependencies if enabled
+	if pb.config.BetterAuth {
+		authDir := filepath.Join(pb.templatesDir, "features", "betterauth", pb.config.Framework)
+		if err := pkg.LoadAndMerge(filepath.Join(authDir, "package.json")); err != nil {
+			return fmt.Errorf("failed to merge better-auth dependencies: %w", err)
+		}
+	}
+
+	// Update project name
+	pkg.Name = pb.config.ProjectName
+
+	// Write final package.json
+	if err := pkg.Write(mainPackagePath); err != nil {
+		return fmt.Errorf("failed to write package.json: %w", err)
+	}
+
+	return nil
+}
+
+// ScaffoldProject is a convenience function that creates and builds a project in one call.
+// It's the main entry point for project scaffolding.
+func ScaffoldProject(cfg Config, targetDir string) error {
+	builder, err := NewProjectBuilder(cfg, targetDir)
+	if err != nil {
+		return err
+	}
+
+	return builder.Build()
 }

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 )
 
-const templatesRepoURL = "https://github.com/albuquerquesz/abacatepay-templates.git"
-
 type ProjectBuilder struct {
 	config       Config
 	templatesDir string

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -1,0 +1,348 @@
+package scaffold
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Config holds the scaffold configuration
+type Config struct {
+	ProjectName string
+	Framework   string
+	Linter      string
+	BetterAuth  bool
+}
+
+// ScaffoldProject creates a new project by composing templates
+func ScaffoldProject(cfg Config, targetDir string) error {
+	// Create temporary directory for cloning
+	tempDir, err := os.MkdirTemp("", "abacate-templates-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Clone templates repository
+	if err := cloneTemplates(tempDir); err != nil {
+		return fmt.Errorf("failed to clone templates: %w", err)
+	}
+
+	templatesDir := filepath.Join(tempDir, "templates")
+
+	// Create project directory
+	projectPath := filepath.Join(targetDir, cfg.ProjectName)
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		return fmt.Errorf("failed to create project directory: %w", err)
+	}
+
+	// 1. Copy base template
+	basePath := filepath.Join(templatesDir, "base", cfg.Framework)
+	if err := copyDir(basePath, projectPath); err != nil {
+		return fmt.Errorf("failed to copy base template: %w", err)
+	}
+
+	// 2. Apply linter
+	if err := applyLinter(templatesDir, cfg.Framework, cfg.Linter, projectPath); err != nil {
+		return fmt.Errorf("failed to apply linter: %w", err)
+	}
+
+	// 3. Apply BetterAuth if enabled
+	if cfg.BetterAuth {
+		if err := applyBetterAuth(templatesDir, cfg.Framework, projectPath); err != nil {
+			return fmt.Errorf("failed to apply better-auth: %w", err)
+		}
+	}
+
+	// 4. Merge package.json files
+	if err := mergePackageJSONs(projectPath, templatesDir, cfg.Framework, cfg.Linter, cfg.BetterAuth); err != nil {
+		return fmt.Errorf("failed to merge package.json: %w", err)
+	}
+
+	// 5. Update project name in package.json
+	if err := updateProjectName(projectPath, cfg.ProjectName); err != nil {
+		return fmt.Errorf("failed to update project name: %w", err)
+	}
+
+	return nil
+}
+
+// cloneTemplates clones the templates repository
+func cloneTemplates(destDir string) error {
+	repoURL := "https://github.com/AbacatePay/templates.git"
+
+	cmd := exec.Command("git", "clone", "--depth", "1", repoURL, destDir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// applyLinter applies the linter configuration to the project
+func applyLinter(templatesDir, framework, linter, projectPath string) error {
+	linterDir := filepath.Join(templatesDir, "linters", linter)
+
+	// Copy config file
+	var configFile string
+	if linter == "eslint" {
+		if framework == "next" {
+			configFile = "eslint.config.next.js"
+		} else {
+			configFile = "eslint.config.elysia.js"
+		}
+		if err := copyFile(
+			filepath.Join(linterDir, configFile),
+			filepath.Join(projectPath, "eslint.config.js"),
+		); err != nil {
+			return err
+		}
+	} else if linter == "biome" {
+		if err := copyFile(
+			filepath.Join(linterDir, "biome.json"),
+			filepath.Join(projectPath, "biome.json"),
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// applyBetterAuth applies better-auth feature to the project
+func applyBetterAuth(templatesDir, framework, projectPath string) error {
+	authDir := filepath.Join(templatesDir, "features", "betterauth", framework)
+
+	// Copy auth files
+	if err := copyDir(authDir, projectPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// mergePackageJSONs merges all package.json fragments into the main package.json
+func mergePackageJSONs(projectPath, templatesDir, framework, linter string, betterAuth bool) error {
+	mainPackagePath := filepath.Join(projectPath, "package.json")
+
+	// Read main package.json
+	mainPkg, err := readPackageJSON(mainPackagePath)
+	if err != nil {
+		return err
+	}
+
+	// Merge linter package.json
+	linterPackagePath := filepath.Join(templatesDir, "linters", linter, "package.json")
+	if err := mergePackageJSON(mainPkg, linterPackagePath); err != nil {
+		return err
+	}
+
+	// Merge linter scripts
+	linterScriptsPath := filepath.Join(templatesDir, "linters", linter, "scripts.json")
+	if err := mergeScripts(mainPkg, linterScriptsPath); err != nil {
+		return err
+	}
+
+	// Merge better-auth if enabled
+	if betterAuth {
+		authPackagePath := filepath.Join(templatesDir, "features", "betterauth", framework, "package.json")
+		if err := mergePackageJSON(mainPkg, authPackagePath); err != nil {
+			return err
+		}
+	}
+
+	// Write merged package.json
+	if err := writePackageJSON(mainPackagePath, mainPkg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// readPackageJSON reads and parses a package.json file
+func readPackageJSON(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var pkg map[string]interface{}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, err
+	}
+
+	return pkg, nil
+}
+
+// mergePackageJSON merges a package.json file into the main package
+func mergePackageJSON(main map[string]interface{}, mergePath string) error {
+	data, err := os.ReadFile(mergePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var merge map[string]interface{}
+	if err := json.Unmarshal(data, &merge); err != nil {
+		return err
+	}
+
+	// Merge dependencies
+	if deps, ok := merge["dependencies"].(map[string]interface{}); ok {
+		if main["dependencies"] == nil {
+			main["dependencies"] = make(map[string]interface{})
+		}
+		mainDeps := main["dependencies"].(map[string]interface{})
+		for k, v := range deps {
+			mainDeps[k] = v
+		}
+	}
+
+	// Merge devDependencies
+	if devDeps, ok := merge["devDependencies"].(map[string]interface{}); ok {
+		if main["devDependencies"] == nil {
+			main["devDependencies"] = make(map[string]interface{})
+		}
+		mainDevDeps := main["devDependencies"].(map[string]interface{})
+		for k, v := range devDeps {
+			mainDevDeps[k] = v
+		}
+	}
+
+	return nil
+}
+
+// mergeScripts merges scripts from a scripts.json file
+func mergeScripts(main map[string]interface{}, scriptsPath string) error {
+	data, err := os.ReadFile(scriptsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var scripts map[string]any
+	if err := json.Unmarshal(data, &scripts); err != nil {
+		return err
+	}
+
+	if scriptsMap, ok := scripts["scripts"].(map[string]any); ok {
+		if main["scripts"] == nil {
+			main["scripts"] = make(map[string]any)
+		}
+		mainScripts := main["scripts"].(map[string]any)
+		maps.Copy(mainScripts, scriptsMap)
+	}
+
+	return nil
+}
+
+func updateProjectName(projectPath, name string) error {
+	pkg, err := readPackageJSON(filepath.Join(projectPath, "package.json"))
+	if err != nil {
+		return err
+	}
+
+	pkg["name"] = name
+
+	return writePackageJSON(filepath.Join(projectPath, "package.json"), pkg)
+}
+
+func writePackageJSON(path string, pkg map[string]any) error {
+	data, err := json.MarshalIndent(pkg, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0o644)
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() && (info.Name() == "node_modules" || info.Name() == ".git") {
+			return filepath.SkipDir
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		dstPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+
+		return copyFile(path, dstPath)
+	})
+}
+
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	return err
+}
+
+func GetNextSteps(cfg Config) []string {
+	steps := []string{
+		fmt.Sprintf("cd %s", cfg.ProjectName),
+		"bun install",
+		"cp .env.example .env",
+	}
+
+	if cfg.Framework == "next" {
+		steps = append(steps, "bun run db:push")
+		steps = append(steps, "bun run dev")
+	} else {
+		steps = append(steps, "bun run db:push")
+		steps = append(steps, "bun run dev")
+	}
+
+	return steps
+}
+
+func ValidateProjectName(name string) error {
+	if name == "" {
+		return fmt.Errorf("project name is required")
+	}
+
+	invalidChars := []string{"/", "\\", ":", "*", "?", "\"", "<", ">", "|"}
+	for _, char := range invalidChars {
+		if strings.Contains(name, char) {
+			return fmt.Errorf("project name cannot contain '%s'", char)
+		}
+	}
+
+	return nil
+}

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -8,14 +8,12 @@ import (
 
 const templatesRepoURL = "https://github.com/AbacatePay/templates.git"
 
-// ProjectBuilder handles the construction of a new project by composing template layers.
 type ProjectBuilder struct {
 	config       Config
 	templatesDir string
 	projectPath  string
 }
 
-// NewProjectBuilder creates a new ProjectBuilder instance.
 func NewProjectBuilder(cfg Config, targetDir string) (*ProjectBuilder, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
@@ -27,29 +25,23 @@ func NewProjectBuilder(cfg Config, targetDir string) (*ProjectBuilder, error) {
 	}, nil
 }
 
-// Build executes the complete project scaffolding process.
-// It clones templates, applies layers, and finalizes the project.
 func (pb *ProjectBuilder) Build() error {
-	// Create temporary directory for templates
 	tempDir, err := os.MkdirTemp("", "abacate-templates-*")
 	if err != nil {
 		return fmt.Errorf("failed to create temp directory: %w", err)
 	}
 	defer os.RemoveAll(tempDir)
 
-	// Clone templates repository
 	if err := pb.cloneTemplates(tempDir); err != nil {
 		return err
 	}
 
 	pb.templatesDir = filepath.Join(tempDir, "templates")
 
-	// Create project directory
 	if err := EnsureDir(pb.projectPath, 0o755); err != nil {
 		return fmt.Errorf("failed to create project directory: %w", err)
 	}
 
-	// Apply template layers
 	if err := pb.applyBaseTemplate(); err != nil {
 		return err
 	}
@@ -69,7 +61,6 @@ func (pb *ProjectBuilder) Build() error {
 	return nil
 }
 
-// cloneTemplates clones the templates repository into the temp directory.
 func (pb *ProjectBuilder) cloneTemplates(tempDir string) error {
 	if err := GitClone(tempDir); err != nil {
 		return fmt.Errorf("failed to clone templates repository: %w", err)
@@ -77,7 +68,6 @@ func (pb *ProjectBuilder) cloneTemplates(tempDir string) error {
 	return nil
 }
 
-// applyBaseTemplate copies the base template for the selected framework.
 func (pb *ProjectBuilder) applyBaseTemplate() error {
 	basePath := filepath.Join(pb.templatesDir, "base", pb.config.Framework)
 
@@ -92,7 +82,6 @@ func (pb *ProjectBuilder) applyBaseTemplate() error {
 	return nil
 }
 
-// applyLinter applies the selected linter configuration to the project.
 func (pb *ProjectBuilder) applyLinter() error {
 	linterDir := filepath.Join(pb.templatesDir, "linters", pb.config.Linter)
 
@@ -110,7 +99,6 @@ func (pb *ProjectBuilder) applyLinter() error {
 	return nil
 }
 
-// applyESLint copies the ESLint configuration file.
 func (pb *ProjectBuilder) applyESLint(linterDir string) error {
 	configFile := "eslint.config.elysia.js"
 	if pb.config.Framework == "next" {
@@ -127,7 +115,6 @@ func (pb *ProjectBuilder) applyESLint(linterDir string) error {
 	return nil
 }
 
-// applyBiome copies the Biome configuration file.
 func (pb *ProjectBuilder) applyBiome(linterDir string) error {
 	src := filepath.Join(linterDir, "biome.json")
 	dst := filepath.Join(pb.projectPath, "biome.json")
@@ -139,7 +126,6 @@ func (pb *ProjectBuilder) applyBiome(linterDir string) error {
 	return nil
 }
 
-// applyFeatures applies selected features (like BetterAuth) to the project.
 func (pb *ProjectBuilder) applyFeatures() error {
 	if pb.config.BetterAuth {
 		if err := pb.applyBetterAuth(); err != nil {
@@ -150,7 +136,6 @@ func (pb *ProjectBuilder) applyFeatures() error {
 	return nil
 }
 
-// applyBetterAuth applies the BetterAuth feature to the project.
 func (pb *ProjectBuilder) applyBetterAuth() error {
 	authDir := filepath.Join(pb.templatesDir, "features", "betterauth", pb.config.Framework)
 
@@ -165,17 +150,14 @@ func (pb *ProjectBuilder) applyBetterAuth() error {
 	return nil
 }
 
-// finalizePackageJSON merges all package.json fragments and updates the project name.
 func (pb *ProjectBuilder) finalizePackageJSON() error {
 	mainPackagePath := filepath.Join(pb.projectPath, "package.json")
 
-	// Read main package.json
 	pkg, err := ReadPackageJSON(mainPackagePath)
 	if err != nil {
 		return fmt.Errorf("failed to read package.json: %w", err)
 	}
 
-	// Merge linter dependencies and scripts
 	linterDir := filepath.Join(pb.templatesDir, "linters", pb.config.Linter)
 	if err := pkg.LoadAndMerge(filepath.Join(linterDir, "package.json")); err != nil {
 		return fmt.Errorf("failed to merge linter dependencies: %w", err)
@@ -184,7 +166,6 @@ func (pb *ProjectBuilder) finalizePackageJSON() error {
 		return fmt.Errorf("failed to merge linter scripts: %w", err)
 	}
 
-	// Merge better-auth dependencies if enabled
 	if pb.config.BetterAuth {
 		authDir := filepath.Join(pb.templatesDir, "features", "betterauth", pb.config.Framework)
 		if err := pkg.LoadAndMerge(filepath.Join(authDir, "package.json")); err != nil {
@@ -192,10 +173,8 @@ func (pb *ProjectBuilder) finalizePackageJSON() error {
 		}
 	}
 
-	// Update project name
 	pkg.Name = pb.config.ProjectName
 
-	// Write final package.json
 	if err := pkg.Write(mainPackagePath); err != nil {
 		return fmt.Errorf("failed to write package.json: %w", err)
 	}
@@ -203,8 +182,6 @@ func (pb *ProjectBuilder) finalizePackageJSON() error {
 	return nil
 }
 
-// ScaffoldProject is a convenience function that creates and builds a project in one call.
-// It's the main entry point for project scaffolding.
 func ScaffoldProject(cfg Config, targetDir string) error {
 	builder, err := NewProjectBuilder(cfg, targetDir)
 	if err != nil {

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -36,7 +36,7 @@ func (pb *ProjectBuilder) Build() error {
 		return err
 	}
 
-	pb.templatesDir = filepath.Join(tempDir, "templates")
+	pb.templatesDir = tempDir
 
 	if err := EnsureDir(pb.projectPath, 0o755); err != nil {
 		return fmt.Errorf("failed to create project directory: %w", err)
@@ -190,4 +190,3 @@ func ScaffoldProject(cfg Config, targetDir string) error {
 
 	return builder.Build()
 }
-

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 )
 
-const templatesRepoURL = "https://github.com/AbacatePay/templates.git"
+const templatesRepoURL = "https://github.com/albuquerquesz/abacatepay-templates.git"
 
 type ProjectBuilder struct {
 	config       Config
@@ -190,3 +190,4 @@ func ScaffoldProject(cfg Config, targetDir string) error {
 
 	return builder.Build()
 }
+


### PR DESCRIPTION
## Summary
Adds `init` command that initializes new projects with interactive scaffolding, allowing choice between frameworks (Next.js/Elysia), linters (ESLint/Biome), and optional BetterAuth configuration.
## Related Issue
Closes (N/A)

## Why
The CLI needed a simple way to create new projects integrated with AbacatePay. Before, developers had to manually clone templates and configure everything by hand. The `init` command automates this entire process with an interactive onboarding flow.

## What changed
- Created `cmd/init.go` with interactive onboarding flow using prompts from the `style` package
- Created `internal/scaffold/config.go` with `Config` structure and validation methods
- Created `internal/scaffold/git.go` for repository clone operations
- Created `internal/scaffold/package.go` for `package.json` manipulation and merging
- Created `internal/scaffold/fs.go` for file and directory copy operations
- Created `internal/scaffold/scaffold.go` with scaffolding orchestration via `ProjectBuilder`
- Implemented layer-based composition system that combines base templates + linters + features (BetterAuth)

## Breaking changes
- [ ] Yes
- [X] No

## Checklist
- [ ] Docs updated
- [X] CI passing
- [X] I followed the CONTRIBUTING guidelines
- [X] I added or updated tests (if applicable)

## Additional context
The command uses a internal repository as the source for templates. The layer-based composition architecture allows adding new frameworks, linters, and features without creating a combinatorial explosion of templates.