### PR TITLE
fix(webhook): sign forwarded events with the real public HMAC key

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Os releases publicam binários para Linux, macOS e Windows nas arquiteturas `amd
 ## Uso rápido
 
 ```bash
-abacatepay login --key "$ABACATEPAY_API_KEY"
+abacatepay login
 abacatepay listen --forward-to http://localhost:3000/webhooks/abacatepay
 abacatepay payments simulate <charge-id>
 ```
@@ -57,19 +57,13 @@ Use `abacatepay <command> -h` para ver as flags de cada comando.
 
 ## Autenticação
 
-A CLI aceita login por chave de API ou pelo fluxo de device login:
-
 ```bash
-# Recomendado para automações e ambientes sem navegador
-abacatepay login --key "$ABACATEPAY_API_KEY"
-
-# Fluxo interativo pelo navegador
 abacatepay login
 ```
 
-A chave fica salva no keyring nativo do sistema operacional. Se nenhum nome for informado com `--name`, a CLI usa o perfil `default`.
+Abre um link no navegador para você aprovar o acesso da CLI na sua conta. O token da sessão fica salvo no keyring nativo do sistema operacional. Se nenhum nome for informado com `--name`, a CLI usa o perfil `default`.
 
-A API v2 usa o mesmo endpoint público para produção e desenvolvimento. O ambiente é determinado pela chave utilizada: chaves de dev mode simulam transações; chaves de produção operam em produção.
+Para sair: `abacatepay logout`.
 
 ## Webhooks
 
@@ -79,14 +73,9 @@ Receba eventos da AbacatePay e encaminhe para sua aplicação local:
 abacatepay listen --forward-to http://localhost:3000/webhooks/abacatepay
 ```
 
-Flags úteis:
+`--forward-to` define a URL local que receberá os eventos (padrão: `http://localhost:3000/webhooks/abacatepay`).
 
-| Flag | Descrição | Padrão |
-| ---- | --------- | ------ |
-| `--forward-to` | URL local que receberá os eventos | `http://localhost:3000/webhooks/abacatepay` |
-| `--mock` | Gera webhooks locais sem conectar na API | `false` |
-
-A CLI assina os eventos encaminhados com o header `X-Abacate-Signature`, facilitando testes locais de validação de assinatura.
+A CLI só recebe eventos de contas/cobranças em `devMode` — produção nunca chega no relay. A CLI assina os eventos encaminhados com o header `X-Webhook-Signature`, usando a mesma chave pública HMAC documentada em [Segurança de Webhooks](https://docs.abacatepay.com/pages/webhooks/security#2-assinatura-hmac). Essa chave é fixa — a verificação que você já implementou seguindo a documentação funciona sem alteração.
 
 ## Pagamentos em dev mode
 

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -19,14 +19,10 @@ var listenCmd = &cobra.Command{
 	},
 }
 
-var (
-	forwardURL string
-	listenMock bool
-)
+var forwardURL string
 
 func init() {
 	listenCmd.Flags().StringVar(&forwardURL, "forward-to", "", "Where incoming events should be sent")
-	listenCmd.Flags().BoolVar(&listenMock, "mock", false, "Simulate incoming webhooks without connecting to the API")
 
 	rootCmd.AddCommand(listenCmd)
 }
@@ -53,7 +49,6 @@ func listen(cmd *cobra.Command) error {
 		Store:      deps.Store,
 		Token:      deps.Token,
 		Version:    cmd.Root().Version,
-		Mock:       listenMock,
 	}
 
 	return utils.StartListener(params)

--- a/internal/crypto/signature.go
+++ b/internal/crypto/signature.go
@@ -3,13 +3,21 @@ package crypto
 import (
 	"crypto/hmac"
 	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
+	"encoding/base64"
 )
 
-func SignWebhookPayload(secret string, timestamp int64, body []byte) string {
-	payload := fmt.Sprintf("%d.%s", timestamp, string(body))
-	h := hmac.New(sha256.New, []byte(secret))
-	h.Write([]byte(payload))
-	return hex.EncodeToString(h.Sum(nil))
+// PublicWebhookKey is AbacatePay's public webhook-signing key, documented at
+// https://docs.abacatepay.com/pages/webhooks/security#2-assinatura-hmac.
+// It is fixed and intentionally not configurable: every webhook AbacatePay
+// relays is signed with this exact key, so verification code written
+// against the public docs works unmodified against events forwarded by
+// this CLI.
+const PublicWebhookKey = "t9dXRhHHo3yDEj5pVDYz0frf7q6bMKyMRmxxCPIPp3RCplBfXRxqlC6ZpiWmOqj4L63qEaeUOtrCI8P0VMUgo6iIga2ri9ogaHFs0WIIywSMg0q7RmBfybe1E5XJcfC4IW3alNqym0tXoAKkzvfEjZxV6bE0oG2zJrNNYmUCKZyV0KZ3JS8Votf9EAWWYdiDkMkpbMdPggfh1EqHlVkMiTady6jOR3hyzGEHrIz2Ret0xHKMbiqkr9HS1JhNHDX9"
+
+// SignWebhookPayload computes the signature AbacatePay uses for webhook
+// delivery: HMAC-SHA256 over the raw body, base64-encoded.
+func SignWebhookPayload(body []byte) string {
+	h := hmac.New(sha256.New, []byte(PublicWebhookKey))
+	h.Write(body)
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
 }

--- a/internal/crypto/signature_test.go
+++ b/internal/crypto/signature_test.go
@@ -1,0 +1,12 @@
+package crypto
+
+import "testing"
+
+func TestSignWebhookPayload_MatchesKnownVector(t *testing.T) {
+	body := []byte(`{"event":"billing.paid","data":{"id":"test"}}`)
+	got := SignWebhookPayload(body)
+	want := "+2VQ4f40+Ffmkpzlb4WFb0rcp3PDG2kSUWdEmWOVzDU="
+	if got != want {
+		t.Fatalf("signature mismatch: got %q, want %q", got, want)
+	}
+}

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -217,13 +217,6 @@ func LogWebhookForwarded(statusCode int, statusText, event string) {
 	)
 }
 
-func LogSigningSecret(secret string) {
-	fmt.Printf("%s Your webhook signing secret is %s\n",
-		lipgloss.NewStyle().Foreground(Palette.Green).Bold(true).Render(">"),
-		lipgloss.NewStyle().Bold(true).Render(secret),
-	)
-}
-
 func Select(title string, options map[string]string) (string, error) {
 	var result string
 	huhOptions := make([]huh.Option[string], 0, len(options))

--- a/internal/utils/listener.go
+++ b/internal/utils/listener.go
@@ -19,14 +19,11 @@ func StartListener(params *StartListenerParams) error {
 	listener := webhook.NewListener(params.Config, params.Client, params.ForwardURL, params.Token, txLogger)
 
 	fmt.Fprintln(os.Stderr)
-	if params.Mock {
-		slog.Info("Running in MOCK mode", "interval", "5s")
-	}
 	slog.Info("Listening for webhooks", "forward_to", params.ForwardURL)
 	fmt.Fprintln(os.Stderr, "Press Ctrl+C to stop")
 	fmt.Fprintln(os.Stderr)
 
-	err = listener.Listen(params.Context, params.Mock)
+	err = listener.Listen(params.Context)
 
 	fmt.Fprintln(os.Stderr)
 	slog.Info("Listener stopped")

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -23,7 +23,6 @@ type StartListenerParams struct {
 	Token      string
 	ForwardURL string
 	Version    string
-	Mock       bool
 }
 
 type Dependencies struct {

--- a/internal/webhook/listener.go
+++ b/internal/webhook/listener.go
@@ -17,47 +17,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func (l *Listener) Listen(ctx context.Context, mock bool) error {
-	if mock {
-		style.LogSigningSecret(l.signingSecret)
-		return l.mockListen(ctx)
-	}
-
+func (l *Listener) Listen(ctx context.Context) error {
 	slog.Info("Starting webhook listener...")
 
 	return ws.ConnectWithRetry(ctx, l.WSConfig(), l.readLoop)
-}
-
-func (l *Listener) mockListen(ctx context.Context) error {
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-ticker.C:
-			id := fmt.Sprintf("pix_char_%d", time.Now().Unix())
-			event := "billing.paid"
-
-			mockData := map[string]any{
-				"event": event,
-				"data": map[string]any{
-					"id":         id,
-					"externalId": "order_123",
-					"amount":     1000,
-					"status":     "PAID",
-				},
-			}
-
-			message, _ := json.Marshal(mockData)
-			l.displayWebhook(webhookMetadata{Event: event, ID: id}, message)
-
-			go func() {
-				_ = l.forward(ctx, message, event)
-			}()
-		}
-	}
 }
 
 func (l *Listener) readLoop(ctx context.Context, conn *websocket.Conn) error {
@@ -146,14 +109,13 @@ func (l *Listener) displayWebhook(meta webhookMetadata, rawBody []byte) {
 
 func (l *Listener) forward(ctx context.Context, message []byte, event string) error {
 	startTime := time.Now()
-	timestamp := time.Now().Unix()
 
-	signature := crypto.SignWebhookPayload(l.signingSecret, timestamp, message)
+	signature := crypto.SignWebhookPayload(message)
 
 	resp, err := l.client.R().
 		SetContext(ctx).
 		SetHeader("Content-Type", "application/json").
-		SetHeader("X-Abacate-Signature", fmt.Sprintf("t=%d,v1=%s", timestamp, signature)).
+		SetHeader("X-Webhook-Signature", signature).
 		SetBody(message).
 		Post(l.forwardURL)
 

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,10 +1,8 @@
 package webhook
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"log/slog"
-	"time"
 
 	"github.com/AbacatePay/abacatepay-cli/internal/config"
 
@@ -23,10 +21,9 @@ type webhookMetadata struct {
 
 type Listener struct {
 	BaseListener
-	client        *resty.Client
-	forwardURL    string
-	txLogger      *slog.Logger
-	signingSecret string
+	client     *resty.Client
+	forwardURL string
+	txLogger   *slog.Logger
 }
 
 func NewListener(cfg *config.Config, client *resty.Client, forwardURL, token string, txLogger *slog.Logger) *Listener {
@@ -35,9 +32,8 @@ func NewListener(cfg *config.Config, client *resty.Client, forwardURL, token str
 			Cfg:   cfg,
 			Token: token,
 		},
-		client:        client,
-		forwardURL:    forwardURL,
-		txLogger:      txLogger,
-		signingSecret: "whsec_mock_" + hex.EncodeToString([]byte(time.Now().Format("150405"))),
+		client:     client,
+		forwardURL: forwardURL,
+		txLogger:   txLogger,
 	}
 }


### PR DESCRIPTION
## Summary

The webhook signature scheme was invented, not real: a random per-run "whsec_mock_..." secret (only ever printed in --mock mode, never in real listen mode - meaning verification was never actually possible), a Stripe-style "t=<ts>,v1=<sig>" header format, and the wrong header name (X-Abacate-Signature). None of it matched what AbacatePay actually documents.

- internal/crypto/signature.go: HMAC-SHA256 over the raw body, base64-encoded, using the fixed public key from https://docs.abacatepay.com/pages/webhooks/security#2-assinatura-hmac. Hardcoded constant, no flag/env/config override.
- Header renamed X-Abacate-Signature -> X-Webhook-Signature.
- Added internal/crypto/signature_test.go asserting a known-vector match, so this can't silently drift again.
- Verified live: real installed binary forwarding to a throwaway server that independently recomputed the HMAC and compared - signatures matched exactly.

Also removes --mock: confirmed in abkt-monorepo that queues/core/webhook.ts gates the entire relay publish behind `if (webhook.devMode)` - production webhooks never reach the relay, for any store, structurally, regardless of session. Given `listen` already only ever receives devMode traffic, --mock's fabricated client-side data no longer serves a purpose. Removed the flag, mockListen(), and the Mock field threading through StartListenerParams/Dependencies/Listener.Listen().

README updates:
- Removed the --key API-key login flow: it stores a raw API key instead of a CLI session token, so the one thing that key can never do is authenticate against services/ws-relay - `listen`, the CLI's core feature, silently fails for anyone who used it. Login is now documented as the single real flow (browser device-flow).
- Restored an accurate webhook-signing claim now that it's true, and documented the devMode-only guarantee.
- Removed --mock from the flags list.

## Related Issue

Closes (N/A)

## Why
What problem does this solve?

## What changed
- 
- 
- 

## Breaking changes
- [x] Yes
- [ ] No

## Checklist
- [x] Docs updated
- [x] CI passing
- [x] I followed the CONTRIBUTING guidelines
- [x] I added or updated tests (if applicable)

## Additional context

Add any other context or screenshots here.
