### PR TITLE
feat: opção para receber webhooks de produção no listen (não só devMode)

### DIFF
--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -19,10 +19,14 @@ var listenCmd = &cobra.Command{
 	},
 }
 
-var forwardURL string
+var (
+	forwardURL string
+	listenEnv  string
+)
 
 func init() {
 	listenCmd.Flags().StringVar(&forwardURL, "forward-to", "", "Where incoming events should be sent")
+	listenCmd.Flags().StringVar(&listenEnv, "env", "dev", "Which environment events to receive: dev, prod, or all")
 
 	rootCmd.AddCommand(listenCmd)
 }
@@ -49,6 +53,7 @@ func listen(cmd *cobra.Command) error {
 		Store:      deps.Store,
 		Token:      deps.Token,
 		Version:    cmd.Root().Version,
+		Env:        listenEnv,
 	}
 
 	return utils.StartListener(params)

--- a/internal/utils/listener.go
+++ b/internal/utils/listener.go
@@ -16,7 +16,7 @@ func StartListener(params *StartListenerParams) error {
 		return fmt.Errorf("failed to initialize transaction logger: %w", err)
 	}
 
-	listener := webhook.NewListener(params.Config, params.Client, params.ForwardURL, params.Token, txLogger)
+	listener := webhook.NewListener(params.Config, params.Client, params.ForwardURL, params.Token, params.Env, txLogger)
 
 	fmt.Fprintln(os.Stderr)
 	slog.Info("Listening for webhooks", "forward_to", params.ForwardURL)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -23,6 +23,7 @@ type StartListenerParams struct {
 	Token      string
 	ForwardURL string
 	Version    string
+	Env        string
 }
 
 type Dependencies struct {

--- a/internal/webhook/listener.go
+++ b/internal/webhook/listener.go
@@ -67,10 +67,18 @@ func (l *Listener) readLoop(ctx context.Context, conn *websocket.Conn) error {
 			Data  struct {
 				ID string `json:"id"`
 			} `json:"data"`
+			DevMode bool `json:"devMode"`
 		}
 
 		if err := json.Unmarshal(message, &raw); err != nil {
 			style.PrintError("Received invalid JSON from WebSocket")
+			continue
+		}
+
+		if l.env == "dev" && !raw.DevMode {
+			continue
+		}
+		if l.env == "prod" && raw.DevMode {
 			continue
 		}
 

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -24,9 +24,10 @@ type Listener struct {
 	client     *resty.Client
 	forwardURL string
 	txLogger   *slog.Logger
+	env        string
 }
 
-func NewListener(cfg *config.Config, client *resty.Client, forwardURL, token string, txLogger *slog.Logger) *Listener {
+func NewListener(cfg *config.Config, client *resty.Client, forwardURL, token, env string, txLogger *slog.Logger) *Listener {
 	return &Listener{
 		BaseListener: BaseListener{
 			Cfg:   cfg,
@@ -35,5 +36,6 @@ func NewListener(cfg *config.Config, client *resty.Client, forwardURL, token str
 		client:     client,
 		forwardURL: forwardURL,
 		txLogger:   txLogger,
+		env:        env,
 	}
 }


### PR DESCRIPTION
## Summary

- Adiciona a flag `--env` (dev | prod | all) no comando `abacatepay listen`.
- Realiza o filtro localmente utilizando o campo booleano `devMode` no payload do webhook antes de despachar o evento para o `--forward-to`.
- **Registro da Decisão sobre Permissões (Critério de Aceite):** Optou-se por controlar a recepção dos eventos por uma **flag simples** na CLI (`--env`), e não através da alteração do protocolo de escopo na aprovação de sessão (login). A validação por flag local mantém o código flexível, garantindo que o padrão continue retrocompatível (só consumindo `devMode`).

Closes #40.