### PR TITLE
feat: standardize CLI output on charmbracelet/bubbles + bubbletea

### DIFF
--- a/cmd/abacatepay/main.go
+++ b/cmd/abacatepay/main.go
@@ -6,17 +6,18 @@ import (
 
 	rootcmd "github.com/AbacatePay/abacatepay-cli/cmd"
 	"github.com/AbacatePay/abacatepay-cli/internal/logger"
+	"github.com/AbacatePay/abacatepay-cli/internal/style"
 )
 
 func main() {
 	logCfg, err := logger.DefaultConfig()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to configure logger: %v\n", err)
+		style.PrintError(fmt.Sprintf("Failed to configure logger: %v", err))
 		os.Exit(1)
 	}
 
 	if _, err := logger.Setup(logCfg); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
+		style.PrintError(fmt.Sprintf("Failed to initialize logger: %v", err))
 		os.Exit(1)
 	}
 

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -2,12 +2,20 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/AbacatePay/abacatepay-cli/internal/logger"
+	"github.com/AbacatePay/abacatepay-cli/internal/output"
+	"github.com/AbacatePay/abacatepay-cli/internal/tui"
 	"github.com/AbacatePay/abacatepay-cli/internal/utils"
+	"github.com/AbacatePay/abacatepay-cli/internal/webhook"
+	"github.com/AbacatePay/abacatepay-cli/internal/ws"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )
 
@@ -41,6 +49,13 @@ func listen(cmd *cobra.Command) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
+	// The live dashboard needs a real terminal to render into, and only
+	// makes sense for the default text output — piped/scripted/CI use (or
+	// -o json/table) keeps the plain sequential-line behavior.
+	if tui.IsInteractive() && output.GetFormat() == output.FormatText {
+		return listenInteractive(ctx, cancel, deps, url)
+	}
+
 	params := &utils.StartListenerParams{
 		Context:    ctx,
 		Config:     deps.Config,
@@ -52,4 +67,47 @@ func listen(cmd *cobra.Command) error {
 	}
 
 	return utils.StartListener(params)
+}
+
+func listenInteractive(ctx context.Context, cancel context.CancelFunc, deps *utils.Dependencies, forwardURL string) error {
+	txLogger, err := utils.SetupTransactionLogger()
+	if err != nil {
+		return fmt.Errorf("failed to initialize transaction logger: %w", err)
+	}
+
+	listener := webhook.NewListener(deps.Config, deps.Client, forwardURL, deps.Token, txLogger)
+
+	// Background slog output (connection retries, heartbeat warnings, ...)
+	// would otherwise corrupt the alt-screen dashboard; it still reaches
+	// the file logger.
+	logger.SetConsoleEnabled(false)
+	defer logger.SetConsoleEnabled(true)
+
+	model := tui.NewListenModel(forwardURL, cancel)
+	program := tea.NewProgram(model, tea.WithAltScreen())
+
+	events := make(chan webhook.Event, 64)
+	listener.Emit = func(e webhook.Event) { events <- e }
+	listener.OnStatus = func(s ws.Status) { program.Send(tui.ConnStatusMsg{Status: s}) }
+
+	go func() {
+		for e := range events {
+			program.Send(e)
+		}
+	}()
+
+	go func() {
+		listenErr := listener.Listen(ctx)
+		close(events)
+
+		if errors.Is(listenErr, context.Canceled) || errors.Is(listenErr, context.DeadlineExceeded) {
+			listenErr = nil
+		}
+		program.Send(tui.StoppedMsg{Err: listenErr})
+	}()
+
+	_, runErr := program.Run()
+	cancel()
+
+	return runErr
 }

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -24,17 +24,17 @@ func init() {
 func logout() error {
 	deps := utils.SetupDependencies(Local, Verbose)
 
-	profile, err := auth.Logout(deps.Store)
-	if err != nil {
-		return err
-	}
+	return output.RunTask("Signing out...", func() (output.Result, error) {
+		profile, err := auth.Logout(deps.Store)
+		if err != nil {
+			return output.Result{}, err
+		}
 
-	output.Print(output.Result{
-		Title: "Signed out successfully",
-		Fields: map[string]string{
-			"Profile": profile,
-		},
+		return output.Result{
+			Title: "Signed out successfully",
+			Fields: map[string]string{
+				"Profile": profile,
+			},
+		}, nil
 	})
-
-	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/AbacatePay/abacatepay-cli/internal/clierr"
 	"github.com/AbacatePay/abacatepay-cli/internal/logger"
 	"github.com/AbacatePay/abacatepay-cli/internal/output"
 	"github.com/AbacatePay/abacatepay-cli/internal/version"
@@ -47,21 +48,23 @@ func Exec() {
 
 		cfg, err := logger.DefaultConfig()
 		if err != nil {
-			h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+			h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logger.ConsoleLevel(level)})
 			slog.SetDefault(slog.New(h))
 			return nil
 		}
 
 		cfg.Level = level
 		if _, err := logger.Setup(cfg); err != nil {
-			h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+			h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logger.ConsoleLevel(level)})
 			slog.SetDefault(slog.New(h))
 		}
 		return nil
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		output.Error(err.Error())
+		if !clierr.AlreadyDisplayed(err) {
+			output.Error(err.Error())
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/AbacatePay/abacatepay-cli/internal/output"
 	"github.com/AbacatePay/abacatepay-cli/internal/version"
 	"github.com/creativeprojects/go-selfupdate"
 	"github.com/spf13/cobra"
@@ -12,7 +13,7 @@ import (
 
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
-	Short: "Atualiza a CLI para a nova versão caso esteja disponível",
+	Short: "Upgrade the CLI to the latest version, if one is available",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return upgrade()
 	},
@@ -25,29 +26,38 @@ func init() {
 func upgrade() error {
 	ctx := context.Background()
 
-	latest, found, err := version.CheckUpdate(ctx, version.Version)
-	if err != nil {
-		return fmt.Errorf("não foi possível checar por atualizações: %w", err)
+	return output.RunTask("Checking for updates...", func() (output.Result, error) {
+		latest, found, err := version.CheckUpdate(ctx, version.Version)
+		if err != nil {
+			return output.Result{}, fmt.Errorf("could not check for updates: %w", err)
+		}
+
+		if !found {
+			return output.Result{
+				Title:  "Already up to date",
+				Fields: map[string]string{"Version": currentVersionLabel()},
+			}, nil
+		}
+
+		exe, err := os.Executable()
+		if err != nil {
+			return output.Result{}, fmt.Errorf("could not resolve executable path: %w", err)
+		}
+
+		if err := selfupdate.UpdateTo(ctx, latest.AssetURL, latest.AssetName, exe); err != nil {
+			return output.Result{}, fmt.Errorf("update failed: %w", err)
+		}
+
+		return output.Result{
+			Title:  "Update complete ✨",
+			Fields: map[string]string{"Version": latest.Version()},
+		}, nil
+	})
+}
+
+func currentVersionLabel() string {
+	if version.Version == "" {
+		return "dev"
 	}
-
-	if !found {
-		fmt.Printf("Você já está na última versão (%s)\n", version.Version)
-		return nil
-	}
-
-	fmt.Printf("Atualização disponível: %s\n", latest.Version())
-	fmt.Println("Baixando e instalando...")
-
-	exe, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("não foi possível obter o caminho do executável: %w", err)
-	}
-
-	if err := selfupdate.UpdateTo(ctx, latest.AssetURL, latest.AssetName, exe); err != nil {
-		return fmt.Errorf("falha na atualização: %w", err)
-	}
-
-	fmt.Println("Atualização concluída ✨")
-
-	return nil
+	return version.Version
 }

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,14 @@ go 1.25.12
 
 require (
 	github.com/99designs/keyring v1.2.2
-	github.com/briandowns/spinner v1.23.0
+	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
+	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/creativeprojects/go-selfupdate v1.6.0
 	github.com/go-resty/resty/v2 v2.11.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/mattn/go-isatty v0.0.20
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/sync v0.22.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -23,8 +25,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
-	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
-	github.com/charmbracelet/bubbletea v1.3.6 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
@@ -35,7 +35,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dvsekhvalnov/jose2go v1.7.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fatih/color v1.16.0 // indirect
 	github.com/go-fed/httpsig v1.1.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/google/go-github/v86 v86.0.0 // indirect
@@ -47,7 +46,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
-github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4Pt2A=
-github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yqeBQJSrbXjuE=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/xnwFfbezlUnFMJy0nusZvytYysV4SCS2cYbvws=

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-resty/resty/v2"
 
 	"github.com/AbacatePay/abacatepay-cli/internal/config"
+	"github.com/AbacatePay/abacatepay-cli/internal/output"
 	"github.com/AbacatePay/abacatepay-cli/internal/store"
 	"github.com/AbacatePay/abacatepay-cli/internal/style"
 
@@ -38,18 +39,24 @@ func Login(params *LoginParams) error {
 }
 
 func loginWithAPIKey(params *LoginParams) error {
-	user, err := ValidateToken(params.Client, params.Config.APIBaseURL, params.APIKey)
-	if err != nil {
-		return err
-	}
+	return output.RunTask("Validating API key...", func() (output.Result, error) {
+		user, err := ValidateToken(params.Client, params.Config.APIBaseURL, params.APIKey)
+		if err != nil {
+			return output.Result{}, err
+		}
 
-	if err := saveAndActivateProfile(params.Store, params.ProfileName, params.APIKey); err != nil {
-		return err
-	}
+		if err := saveAndActivateProfile(params.Store, params.ProfileName, params.APIKey); err != nil {
+			return output.Result{}, err
+		}
 
-	fmt.Printf("Welcome back, %s\nProfile: %s\n", user.Name, profileName(params.ProfileName))
-
-	return nil
+		return output.Result{
+			Title: "Welcome back",
+			Fields: map[string]string{
+				"User":    user.Name,
+				"Profile": profileName(params.ProfileName),
+			},
+		}, nil
+	})
 }
 
 func loginWithDeviceFlow(params *LoginParams) error {
@@ -82,27 +89,33 @@ func loginWithDeviceFlow(params *LoginParams) error {
 	approvalURL := params.Config.AppBaseURL + "/oauth/cli?id=" + result.Data.PublicID
 
 	if !tryOpenBrowser(params, approvalURL) {
-		fmt.Println("Open the link below to continue authentication:")
-		fmt.Printf("%s\n", approvalURL)
+		style.PrintInfo("Open the link below to continue authentication:")
+		fmt.Println(style.ValueStyle.Render(approvalURL))
 	}
 
-	token, err := pollForToken(params.Context, params.Config, params.Client, result.Data.PublicID)
-	if err != nil {
-		return err
-	}
+	return output.RunTask("Waiting for authorization...", func() (output.Result, error) {
+		token, err := pollForTokenLoop(params.Context, params.Config, params.Client, result.Data.PublicID)
+		if err != nil {
+			return output.Result{}, err
+		}
 
-	user, err := ValidateToken(params.Client, params.Config.APIBaseURL, token)
-	if err != nil {
-		return err
-	}
+		user, err := ValidateToken(params.Client, params.Config.APIBaseURL, token)
+		if err != nil {
+			return output.Result{}, err
+		}
 
-	if err := saveAndActivateProfile(params.Store, params.ProfileName, token); err != nil {
-		return err
-	}
+		if err := saveAndActivateProfile(params.Store, params.ProfileName, token); err != nil {
+			return output.Result{}, err
+		}
 
-	fmt.Printf("Authenticated as %s\nProfile: %s\n", user.Name, profileName(params.ProfileName))
-
-	return nil
+		return output.Result{
+			Title: "Authenticated",
+			Fields: map[string]string{
+				"User":    user.Name,
+				"Profile": profileName(params.ProfileName),
+			},
+		}, nil
+	})
 }
 
 func saveAndActivateProfile(st store.TokenStore, profile, token string) error {
@@ -137,7 +150,7 @@ func tryOpenBrowser(params *LoginParams, verificationURI string) bool {
 		return false
 	}
 
-	fmt.Printf("Opening browser: %s\n", verificationURI)
+	style.PrintInfo("Opening browser: " + verificationURI)
 
 	return true
 }
@@ -178,10 +191,7 @@ func Logout(st store.TokenStore) (string, error) {
 	return activeProfile, nil
 }
 
-func pollForToken(ctx context.Context, cfg *config.Config, client *resty.Client, id string) (string, error) {
-	s := style.Spinner()
-	defer s.Stop()
-
+func pollForTokenLoop(ctx context.Context, cfg *config.Config, client *resty.Client, id string) (string, error) {
 	ticker := time.NewTicker(2 * time.Second)
 
 	defer ticker.Stop()

--- a/internal/auth/login_test.go
+++ b/internal/auth/login_test.go
@@ -114,7 +114,7 @@ func TestPollForToken_Rejected(t *testing.T) {
 	defer server.Close()
 
 	cfg := &config.Config{APIBaseURL: server.URL}
-	if _, err := pollForToken(context.Background(), cfg, newTestClient(), "cli_rejected"); err == nil {
+	if _, err := pollForTokenLoop(context.Background(), cfg, newTestClient(), "cli_rejected"); err == nil {
 		t.Fatal("expected an error for a rejected login request")
 	}
 }
@@ -130,7 +130,7 @@ func TestPollForToken_Expired(t *testing.T) {
 	defer server.Close()
 
 	cfg := &config.Config{APIBaseURL: server.URL}
-	if _, err := pollForToken(context.Background(), cfg, newTestClient(), "cli_expired"); err == nil {
+	if _, err := pollForTokenLoop(context.Background(), cfg, newTestClient(), "cli_expired"); err == nil {
 		t.Fatal("expected an error for an expired login request")
 	}
 }
@@ -142,7 +142,7 @@ func TestPollForToken_NotFound(t *testing.T) {
 	defer server.Close()
 
 	cfg := &config.Config{APIBaseURL: server.URL}
-	if _, err := pollForToken(context.Background(), cfg, newTestClient(), "cli_missing"); err == nil {
+	if _, err := pollForTokenLoop(context.Background(), cfg, newTestClient(), "cli_missing"); err == nil {
 		t.Fatal("expected an error for a not-found login request")
 	}
 }

--- a/internal/clierr/clierr.go
+++ b/internal/clierr/clierr.go
@@ -1,0 +1,28 @@
+// Package clierr marks errors that have already been shown to the user, so
+// the top-level command runner doesn't print them a second time. It has no
+// internal dependencies so every layer (ws, payments, output, tui, cmd) can
+// import it without creating an import cycle.
+package clierr
+
+import "errors"
+
+type displayed struct{ err error }
+
+func (e *displayed) Error() string { return e.err.Error() }
+func (e *displayed) Unwrap() error { return e.err }
+
+// MarkDisplayed wraps err to record that it has already been shown to the
+// user (a styled box, a TUI render, ...). Returns nil unchanged.
+func MarkDisplayed(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &displayed{err: err}
+}
+
+// AlreadyDisplayed reports whether err, or anything it wraps, was marked via
+// MarkDisplayed.
+func AlreadyDisplayed(err error) bool {
+	var d *displayed
+	return errors.As(err, &d)
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -6,9 +6,65 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 
 	"gopkg.in/natefinch/lumberjack.v2"
 )
+
+var consoleEnabled atomic.Bool
+
+func init() {
+	consoleEnabled.Store(true)
+}
+
+// ConsoleLevel derives the console handler's threshold from the configured
+// file-log level. Every operational log call in this codebase (Info/Debug/
+// Warn - there is no slog.Error call site; user-facing failures always go
+// through output.Error/style.PrintError instead) is internal diagnostic
+// detail, already reflected where it matters through the CLI's styled
+// success/error/event output. Echoing it again as raw `level=INFO
+// msg=...` text on stderr is redundant and visually inconsistent with that
+// styling, so by default none of it reaches the console - only the file
+// handler. Console only mirrors the file level once verbose mode (Debug) is
+// on, when raw diagnostic detail is exactly what was asked for.
+func ConsoleLevel(base slog.Level) slog.Level {
+	if base <= slog.LevelDebug {
+		return base
+	}
+	return slog.LevelError + 1
+}
+
+// SetConsoleEnabled toggles whether the console (stderr) log handler emits
+// output. Callers that take over the terminal (e.g. a bubbletea alt-screen
+// program) should disable it for the duration to avoid corrupting the
+// display, then restore it afterwards. Log records still reach the file
+// handler regardless of this setting.
+func SetConsoleEnabled(enabled bool) {
+	consoleEnabled.Store(enabled)
+}
+
+type toggleHandler struct {
+	inner slog.Handler
+}
+
+func (h *toggleHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return consoleEnabled.Load() && h.inner.Enabled(ctx, level)
+}
+
+func (h *toggleHandler) Handle(ctx context.Context, r slog.Record) error {
+	if !consoleEnabled.Load() {
+		return nil
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *toggleHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &toggleHandler{inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h *toggleHandler) WithGroup(name string) slog.Handler {
+	return &toggleHandler{inner: h.inner.WithGroup(name)}
+}
 
 type Config struct {
 	LogDir     string
@@ -50,15 +106,15 @@ func Setup(cfg *Config) (*slog.Logger, error) {
 
 	fileHandler := slog.NewJSONHandler(logFile, &slog.HandlerOptions{Level: cfg.Level})
 
-	consoleHandler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: cfg.Level,
+	consoleHandler := &toggleHandler{inner: slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: ConsoleLevel(cfg.Level),
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			if a.Key == slog.TimeKey && len(groups) == 0 {
 				return slog.Attr{}
 			}
 			return a
 		},
-	})
+	})}
 
 	multiHandler := NewFanoutHandler(consoleHandler, fileHandler)
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/AbacatePay/abacatepay-cli/internal/clierr"
 	"github.com/AbacatePay/abacatepay-cli/internal/style"
+	"github.com/AbacatePay/abacatepay-cli/internal/tui"
 )
 
 type Format string
@@ -72,6 +74,37 @@ func Print(r Result) {
 	default:
 		printText(r)
 	}
+}
+
+// RunTask runs fn and displays its outcome according to the current output
+// format. In JSON/table mode it runs fn immediately and prints the result
+// (or error) through Print/Error, same as any other command. In text mode
+// it shows an animated spinner (via tui.RunTask) while fn runs, and the
+// spinner's final frame becomes the result box - one continuous render, not
+// a spinner followed by a separately-printed box.
+//
+// Either way, RunTask itself displays a non-nil error before returning it,
+// so the returned error is wrapped with clierr.MarkDisplayed - callers
+// (ultimately cmd.Exec's top-level handler) must check clierr.AlreadyDisplayed
+// before printing it again.
+//
+// fn must not print to stdout itself; see tui.RunTask.
+func RunTask(message string, fn func() (Result, error)) error {
+	if GetFormat() != FormatText {
+		r, err := fn()
+		if err != nil {
+			Error(err.Error())
+			return clierr.MarkDisplayed(err)
+		}
+		Print(r)
+		return nil
+	}
+
+	err := tui.RunTask(message, func() (tui.TaskResult, error) {
+		r, err := fn()
+		return tui.TaskResult{Title: r.Title, Fields: r.Fields}, err
+	})
+	return clierr.MarkDisplayed(err)
 }
 
 func Error(msg string) {

--- a/internal/payments/payments.go
+++ b/internal/payments/payments.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/AbacatePay/abacatepay-cli/internal/clierr"
 	"github.com/AbacatePay/abacatepay-cli/internal/output"
 	"github.com/AbacatePay/abacatepay-cli/internal/style"
 	"github.com/AbacatePay/abacatepay-cli/internal/types"
@@ -28,7 +29,7 @@ func New(client *resty.Client, baseURL string, verbose bool) *Service {
 
 func (s *Service) executeRequest(req *resty.Request, method, url string, result any) error {
 	if s.Verbose {
-		fmt.Printf("Request: %s %s\n", method, url)
+		fmt.Printf("%s %s %s\n", style.LabelStyle.Render("Request:"), method, style.ValueStyle.Render(url))
 		if body := req.Body; body != nil {
 			if b, ok := body.([]byte); ok {
 				var pretty any
@@ -61,7 +62,7 @@ func (s *Service) executeRequest(req *resty.Request, method, url string, result 
 	}
 
 	if s.Verbose {
-		fmt.Printf("Response: %s\n", resp.Status())
+		fmt.Printf("%s %s\n", style.LabelStyle.Render("Response:"), style.ValueStyle.Render(resp.Status()))
 	}
 
 	if resp.IsError() {
@@ -100,5 +101,5 @@ func (s *Service) handleAPIError(resp *resty.Response) error {
 		output.Error(errorMessage)
 	}
 
-	return fmt.Errorf("API Error: %s", errorMessage)
+	return clierr.MarkDisplayed(fmt.Errorf("API Error: %s", errorMessage))
 }

--- a/internal/payments/pix_qrcode.go
+++ b/internal/payments/pix_qrcode.go
@@ -1,35 +1,53 @@
 package payments
 
 import (
+	"github.com/AbacatePay/abacatepay-cli/internal/clierr"
 	"github.com/AbacatePay/abacatepay-cli/internal/output"
 	"github.com/AbacatePay/abacatepay-cli/internal/types"
 )
 
 func (s *Service) SimulateTransparentPayment(id string) error {
-	var result types.TransparentPaymentResponse
-	err := s.executeRequest(
-		s.Client.R().
-			SetQueryParam("id", id).
-			SetBody(types.SimulatePaymentRequest{Metadata: map[string]any{}}),
-		"POST",
-		s.BaseURL+"/v2/transparents/simulate-payment",
-		&result,
-	)
-	if err != nil {
-		return err
+	action := func() (output.Result, error) {
+		var result types.TransparentPaymentResponse
+		err := s.executeRequest(
+			s.Client.R().
+				SetQueryParam("id", id).
+				SetBody(types.SimulatePaymentRequest{Metadata: map[string]any{}}),
+			"POST",
+			s.BaseURL+"/v2/transparents/simulate-payment",
+			&result,
+		)
+		if err != nil {
+			return output.Result{}, err
+		}
+
+		return output.Result{
+			Title: "Payment Simulated",
+			Fields: map[string]string{
+				"ID":      result.Data.ID,
+				"Status":  result.Data.Status,
+				"DevMode": boolLabel(result.Data.DevMode),
+			},
+			Data: result,
+		}, nil
 	}
 
-	output.Print(output.Result{
-		Title: "Payment Simulated",
-		Fields: map[string]string{
-			"ID":      result.Data.ID,
-			"Status":  result.Data.Status,
-			"DevMode": boolLabel(result.Data.DevMode),
-		},
-		Data: result,
-	})
+	// Verbose mode prints its own request/response dump from inside
+	// executeRequest; a spinner animating concurrently would race with (and
+	// garble) that output, so skip the TUI and go straight through.
+	if s.Verbose {
+		r, err := action()
+		if err != nil {
+			if !clierr.AlreadyDisplayed(err) {
+				output.Error(err.Error())
+			}
+			return err
+		}
+		output.Print(r)
+		return nil
+	}
 
-	return nil
+	return output.RunTask("Simulating payment...", action)
 }
 
 func boolLabel(v bool) string {

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -3,12 +3,13 @@ package style
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 	"sort"
 	"strings"
 	"time"
 
-	"github.com/briandowns/spinner"
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
@@ -56,23 +57,7 @@ var (
 	ErrorStyle = lipgloss.NewStyle().
 			Foreground(Palette.SoftRed).
 			Bold(true)
-
-	BoxStyle = lipgloss.NewStyle().
-			BorderStyle(lipgloss.RoundedBorder()).
-			BorderForeground(Palette.Green).
-			Padding(1, 2).
-			MarginTop(1).
-			MarginBottom(1)
 )
-
-func Spinner() *spinner.Spinner {
-	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
-	s.Suffix = " Waiting for authorization..."
-
-	s.Start()
-
-	return s
-}
 
 func AbacateTheme() *huh.Theme {
 	t := huh.ThemeBase()
@@ -153,22 +138,45 @@ func SimpleList(items []string, activeItem string) {
 	fmt.Println("")
 }
 
-func PrintSuccess(title string, fields map[string]string) {
+// RenderSuccess returns the success rendering used by PrintSuccess: a title
+// line followed by "label: value" lines, no border/box. Shared with the
+// interactive tui.RunTask so a spinner-then-result flow ends in the exact
+// same text, drawn by the same code, instead of two disconnected passes.
+func RenderSuccess(title string, fields map[string]string) string {
 	var sb strings.Builder
-	sb.WriteString(TitleStyle.Render("🥑 "+title) + "\n\n")
+	sb.WriteString(TitleStyle.Render("🥑 " + title))
 	for label, value := range fields {
-		fmt.Fprintf(&sb, "%s %s\n", LabelStyle.Render(label+":"), ValueStyle.Render(value))
+		fmt.Fprintf(&sb, "\n%s %s", LabelStyle.Render(label+":"), ValueStyle.Render(value))
 	}
-	fmt.Println(BoxStyle.Render(sb.String()))
+	return sb.String()
+}
+
+func PrintSuccess(title string, fields map[string]string) {
+	fmt.Println(RenderSuccess(title, fields))
+}
+
+// PrintInfo prints a de-emphasized transient status line - e.g. instructions
+// shown before a spinner starts. Keeps output consistently styled instead of
+// falling back to a bare fmt.Println.
+func PrintInfo(msg string) {
+	FprintInfo(os.Stdout, msg)
+}
+
+// FprintInfo is PrintInfo for an arbitrary writer, for callers (like the
+// non-interactive `listen` banner) that intentionally keep status text on
+// stderr so piped stdout data stays clean.
+func FprintInfo(w io.Writer, msg string) {
+	fmt.Fprintln(w, LabelStyle.Render(msg))
+}
+
+// RenderError returns the error rendering used by PrintError, no border/box.
+// See RenderSuccess.
+func RenderError(err string) string {
+	return ErrorStyle.Render("⚠️  Error:") + " " + lipgloss.NewStyle().Foreground(Palette.White).Render(err)
 }
 
 func PrintError(err string) {
-	fmt.Println(BoxStyle.
-		BorderForeground(Palette.SoftRed).
-		Padding(0, 1).
-		Render(
-			ErrorStyle.Render("⚠️  Error") + "\n\n" + lipgloss.NewStyle().Foreground(Palette.White).Render(err),
-		))
+	fmt.Println(RenderError(err))
 }
 
 func PrintVerifyError(expected, received string) {
@@ -184,12 +192,15 @@ func PrintVerifyError(expected, received string) {
 	sb.WriteString(lipgloss.NewStyle().Foreground(Palette.White).Render("2. Wrong secret key used.") + "\n")
 	sb.WriteString(lipgloss.NewStyle().Foreground(Palette.White).Render("3. Timestamp manipulation."))
 
-	fmt.Println(BoxStyle.BorderForeground(Palette.SoftRed).Render(sb.String()))
+	fmt.Println(sb.String())
 }
 
-func LogWebhookReceived(event, id string) {
+// RenderWebhookReceived renders a single received-webhook line. It's the
+// single source of truth for that line's look, shared by LogWebhookReceived
+// (plain sequential output) and the interactive listen dashboard.
+func RenderWebhookReceived(event, id string) string {
 	timestamp := time.Now().Format("15:04:05")
-	fmt.Printf("%s  %s %s [%s]\n",
+	return fmt.Sprintf("%s  %s %s [%s]",
 		lipgloss.NewStyle().Foreground(Palette.Gray).Render(timestamp),
 		lipgloss.NewStyle().Foreground(Palette.Green).Bold(true).Render("-->"),
 		lipgloss.NewStyle().Bold(true).Render(event),
@@ -197,7 +208,9 @@ func LogWebhookReceived(event, id string) {
 	)
 }
 
-func LogWebhookForwarded(statusCode int, statusText, event string) {
+// RenderWebhookForwarded renders a single forwarded-webhook line. See
+// RenderWebhookReceived.
+func RenderWebhookForwarded(statusCode int, statusText, event string) string {
 	timestamp := time.Now().Format("15:04:05")
 	codeColor := Palette.Green
 	if statusCode < 200 || statusCode >= 300 {
@@ -207,7 +220,7 @@ func LogWebhookForwarded(statusCode int, statusText, event string) {
 	codeStyle := lipgloss.NewStyle().Foreground(codeColor).Bold(true)
 	bracketStyle := lipgloss.NewStyle().Foreground(Palette.Gray)
 
-	fmt.Printf("%s  %s %s%s%s %s\n",
+	return fmt.Sprintf("%s  %s %s%s%s %s",
 		lipgloss.NewStyle().Foreground(Palette.Gray).Render(timestamp),
 		lipgloss.NewStyle().Foreground(Palette.Green).Bold(true).Render("<--"),
 		bracketStyle.Render("["),
@@ -215,6 +228,14 @@ func LogWebhookForwarded(statusCode int, statusText, event string) {
 		bracketStyle.Render("]"),
 		lipgloss.NewStyle().Bold(true).Render(event),
 	)
+}
+
+func LogWebhookReceived(event, id string) {
+	fmt.Println(RenderWebhookReceived(event, id))
+}
+
+func LogWebhookForwarded(statusCode int, statusText, event string) {
+	fmt.Println(RenderWebhookForwarded(statusCode, statusText, event))
 }
 
 func Select(title string, options map[string]string) (string, error) {
@@ -242,12 +263,15 @@ func Confirm(title string, value *bool) error {
 	return form.Run()
 }
 
-func PrintJSON(data any) {
+// RenderJSON marshals data and returns it syntax-highlighted, matching the
+// coloring PrintJSON writes to stdout. It's the single source of truth for
+// that highlighting, shared with callers (like the interactive listen
+// dashboard) that need the string instead of a direct print.
+func RenderJSON(data any) string {
 	b, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		slog.Debug("failed to marshal JSON for display", "error", err)
-		fmt.Println(data)
-		return
+		return fmt.Sprint(data)
 	}
 
 	str := string(b)
@@ -327,5 +351,9 @@ func PrintJSON(data any) {
 		result.WriteByte(char)
 	}
 
-	fmt.Println(result.String())
+	return result.String()
+}
+
+func PrintJSON(data any) {
+	fmt.Println(RenderJSON(data))
 }

--- a/internal/tui/listen.go
+++ b/internal/tui/listen.go
@@ -1,0 +1,218 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AbacatePay/abacatepay-cli/internal/style"
+	"github.com/AbacatePay/abacatepay-cli/internal/webhook"
+	"github.com/AbacatePay/abacatepay-cli/internal/ws"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ConnStatusMsg reports a change in connection status. Send it into a
+// running Program (via Program.Send) to update the dashboard header.
+type ConnStatusMsg struct {
+	Status ws.Status
+}
+
+// StoppedMsg signals that the listener's Listen call returned - the socket
+// loop exited, for any reason (including the user quitting). Send it into
+// the Program when that happens so the header reflects it if still open.
+type StoppedMsg struct{ Err error }
+
+const maxEventLines = 500
+
+type listenKeyMap struct {
+	Up     key.Binding
+	Down   key.Binding
+	Bottom key.Binding
+	Quit   key.Binding
+}
+
+func (k listenKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Up, k.Down, k.Bottom, k.Quit}
+}
+
+func (k listenKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{k.ShortHelp()}
+}
+
+var listenKeys = listenKeyMap{
+	Up:     key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
+	Down:   key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
+	Bottom: key.NewBinding(key.WithKeys("end", "G"), key.WithHelp("G", "latest")),
+	Quit:   key.NewBinding(key.WithKeys("q", "ctrl+c", "esc"), key.WithHelp("q", "quit")),
+}
+
+// ListenModel is the bubbletea dashboard shown by the interactive `listen`
+// command: a live, scrollable feed of received/forwarded webhooks.
+type ListenModel struct {
+	forwardURL string
+	cancel     func()
+
+	spin spinner.Model
+	vp   viewport.Model
+	help help.Model
+
+	status  ws.Status
+	stopped bool
+	stopErr error
+
+	lines []string
+	ready bool
+}
+
+// NewListenModel builds the dashboard model. cancel is invoked exactly once,
+// when the user quits, so the caller can tear down the context driving the
+// underlying websocket loop.
+func NewListenModel(forwardURL string, cancel func()) *ListenModel {
+	s := spinner.New()
+	s.Spinner = spinner.MiniDot
+	s.Style = lipgloss.NewStyle().Foreground(style.Palette.Green)
+
+	return &ListenModel{
+		forwardURL: forwardURL,
+		cancel:     cancel,
+		spin:       s,
+		help:       help.New(),
+		status:     ws.StatusConnecting,
+	}
+}
+
+func (m *ListenModel) Init() tea.Cmd {
+	return m.spin.Tick
+}
+
+func (m *ListenModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.resize(msg.Width, msg.Height)
+		return m, nil
+
+	case tea.KeyMsg:
+		if key.Matches(msg, listenKeys.Quit) {
+			if m.cancel != nil {
+				m.cancel()
+			}
+			return m, tea.Quit
+		}
+		if key.Matches(msg, listenKeys.Bottom) {
+			m.vp.GotoBottom()
+			return m, nil
+		}
+
+	case webhook.Event:
+		m.appendEvent(msg)
+		return m, nil
+
+	case ConnStatusMsg:
+		m.status = msg.Status
+		return m, nil
+
+	case StoppedMsg:
+		m.stopped = true
+		m.stopErr = msg.Err
+		return m, nil
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spin, cmd = m.spin.Update(msg)
+		return m, cmd
+	}
+
+	if !m.ready {
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	m.vp, cmd = m.vp.Update(msg)
+	return m, cmd
+}
+
+func (m *ListenModel) resize(width, height int) {
+	headerHeight := lipgloss.Height(m.headerView())
+	footerHeight := lipgloss.Height(m.footerView())
+	vpHeight := height - headerHeight - footerHeight
+	if vpHeight < 0 {
+		vpHeight = 0
+	}
+
+	if !m.ready {
+		m.vp = viewport.New(width, vpHeight)
+		m.vp.SetContent(strings.Join(m.lines, "\n"))
+		m.ready = true
+	} else {
+		m.vp.Width = width
+		m.vp.Height = vpHeight
+	}
+
+	m.help.Width = width
+}
+
+func (m *ListenModel) appendEvent(e webhook.Event) {
+	var line string
+	switch e.Kind {
+	case webhook.EventReceived:
+		line = style.RenderWebhookReceived(e.Name, e.ID)
+		if e.RawJSON != "" {
+			line += "\n" + e.RawJSON
+		}
+	case webhook.EventForwarded:
+		line = style.RenderWebhookForwarded(e.StatusCode, e.StatusText, e.Name)
+	case webhook.EventInvalid:
+		line = lipgloss.NewStyle().Foreground(style.Palette.SoftRed).Render("received invalid JSON from WebSocket")
+	default:
+		return
+	}
+
+	m.lines = append(m.lines, line)
+	if len(m.lines) > maxEventLines {
+		m.lines = m.lines[len(m.lines)-maxEventLines:]
+	}
+
+	if m.ready {
+		m.vp.SetContent(strings.Join(m.lines, "\n"))
+	}
+}
+
+func (m *ListenModel) headerView() string {
+	var status string
+	switch {
+	case m.stopped:
+		mark := lipgloss.NewStyle().Foreground(style.Palette.SoftRed).Bold(true).Render("✗ stopped")
+		status = mark
+		if m.stopErr != nil {
+			status += lipgloss.NewStyle().Foreground(style.Palette.Gray).Render(" (" + m.stopErr.Error() + ")")
+		}
+	case m.status == ws.StatusConnected:
+		status = lipgloss.NewStyle().Foreground(style.Palette.Green).Bold(true).Render("● connected")
+	case m.status == ws.StatusRetrying:
+		status = m.spin.View() + " reconnecting..."
+	default:
+		status = m.spin.View() + " connecting..."
+	}
+
+	title := style.TitleStyle.Render("🥑 abacatepay listen")
+	forward := style.LabelStyle.Render("forwarding to ") + style.ValueStyle.Render(m.forwardURL)
+
+	return lipgloss.JoinVertical(lipgloss.Left, title, status+"  "+forward, "")
+}
+
+func (m *ListenModel) footerView() string {
+	return "\n" + m.help.View(listenKeys)
+}
+
+func (m *ListenModel) View() string {
+	if !m.ready {
+		return fmt.Sprintf("%s\nInitializing…", m.headerView())
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left, m.headerView(), m.vp.View(), m.footerView())
+}

--- a/internal/tui/task.go
+++ b/internal/tui/task.go
@@ -1,0 +1,118 @@
+package tui
+
+import (
+	"fmt"
+
+	"github.com/AbacatePay/abacatepay-cli/internal/style"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TaskResult is what a Task renders once it finishes successfully.
+type TaskResult struct {
+	Title  string
+	Fields map[string]string
+}
+
+// RunTask runs fn with an animated spinner next to message, then renders its
+// outcome - success or error text, using the exact same rendering
+// RenderSuccess/RenderError draw everywhere else - as part of the same
+// continuous render. There is no separate print step after the spinner: the
+// spinner frame is simply replaced by the final text in place, so a
+// command's entire visible output is one uninterrupted TUI render instead of
+// a bubbletea animation followed by a disconnected plain fmt.Println.
+//
+// fn must not print to stdout itself - anything it writes while the spinner
+// is animating races the renderer and corrupts the display. Callers that
+// need to show verbose/debug output should skip RunTask entirely for that
+// invocation and print directly instead.
+//
+// When stdout isn't a terminal, RunTask prints message once and renders the
+// final result as a plain line, matching how every other styled output
+// falls back for piped/scripted use.
+func RunTask(message string, fn func() (TaskResult, error)) error {
+	if !IsInteractive() {
+		style.PrintInfo(message)
+
+		res, err := fn()
+		if err != nil {
+			style.PrintError(err.Error())
+			return err
+		}
+
+		style.PrintSuccess(res.Title, res.Fields)
+		return nil
+	}
+
+	m := newTaskModel(message, fn)
+
+	final, runErr := tea.NewProgram(m).Run()
+	if runErr != nil {
+		return runErr
+	}
+
+	return final.(taskModel).err
+}
+
+type taskDoneMsg struct {
+	result TaskResult
+	err    error
+}
+
+type taskModel struct {
+	spin    spinner.Model
+	message string
+	fn      func() (TaskResult, error)
+	done    bool
+	result  TaskResult
+	err     error
+}
+
+func newTaskModel(message string, fn func() (TaskResult, error)) taskModel {
+	s := spinner.New()
+	s.Spinner = spinner.MiniDot
+	s.Style = lipgloss.NewStyle().Foreground(style.Palette.Green)
+
+	return taskModel{spin: s, message: message, fn: fn}
+}
+
+func (m taskModel) Init() tea.Cmd {
+	return tea.Batch(m.spin.Tick, runTaskFn(m.fn))
+}
+
+func runTaskFn(fn func() (TaskResult, error)) tea.Cmd {
+	return func() tea.Msg {
+		res, err := fn()
+		return taskDoneMsg{result: res, err: err}
+	}
+}
+
+func (m taskModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case taskDoneMsg:
+		m.done = true
+		m.result = msg.result
+		m.err = msg.err
+		return m, tea.Quit
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spin, cmd = m.spin.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m taskModel) View() string {
+	if m.done {
+		if m.err != nil {
+			return style.RenderError(m.err.Error())
+		}
+		return style.RenderSuccess(m.result.Title, m.result.Fields)
+	}
+
+	return fmt.Sprintf("%s %s\n", m.spin.View(), m.message)
+}

--- a/internal/tui/tty.go
+++ b/internal/tui/tty.go
@@ -1,0 +1,15 @@
+package tui
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+// IsInteractive reports whether stdout is attached to a terminal. Dynamic
+// (bubbletea-driven) output should only be used when this is true; otherwise
+// callers should fall back to plain sequential output so piped/scripted use
+// keeps working.
+func IsInteractive() bool {
+	return isatty.IsTerminal(os.Stdout.Fd())
+}

--- a/internal/utils/listener.go
+++ b/internal/utils/listener.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/AbacatePay/abacatepay-cli/internal/style"
 	"github.com/AbacatePay/abacatepay-cli/internal/webhook"
 )
 
@@ -18,15 +19,19 @@ func StartListener(params *StartListenerParams) error {
 
 	listener := webhook.NewListener(params.Config, params.Client, params.ForwardURL, params.Token, txLogger)
 
+	// User-facing status goes to stderr (styled) so piped stdout stays clean
+	// webhook-event data; slog.Info here is the file-only diagnostic trail.
 	fmt.Fprintln(os.Stderr)
 	slog.Info("Listening for webhooks", "forward_to", params.ForwardURL)
-	fmt.Fprintln(os.Stderr, "Press Ctrl+C to stop")
+	style.FprintInfo(os.Stderr, fmt.Sprintf("Listening for webhooks — forwarding to %s", params.ForwardURL))
+	style.FprintInfo(os.Stderr, "Press Ctrl+C to stop")
 	fmt.Fprintln(os.Stderr)
 
 	err = listener.Listen(params.Context)
 
 	fmt.Fprintln(os.Stderr)
 	slog.Info("Listener stopped")
+	style.FprintInfo(os.Stderr, "Listener stopped")
 
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -6,7 +6,7 @@ import (
 	"github.com/creativeprojects/go-selfupdate"
 )
 
-// CheckUpdate verifica se há uma versão mais nova da CLI no GitHub
+// CheckUpdate checks whether a newer CLI version is available on GitHub.
 func CheckUpdate(ctx context.Context, currentVersion string) (*selfupdate.Release, bool, error) {
 	slug := "AbacatePay/abacatepay-cli"
 

--- a/internal/webhook/base_listener.go
+++ b/internal/webhook/base_listener.go
@@ -17,6 +17,14 @@ type BaseListener struct {
 	Cfg    *config.Config
 	Token  string
 	ConnMu sync.Mutex
+
+	// Emit, if set, receives every Event instead of the default plain-line
+	// output. Left nil, listeners behave exactly as before.
+	Emit func(Event)
+
+	// OnStatus, if set, receives connection lifecycle transitions (dialing,
+	// connected, retrying). Left nil, no-op.
+	OnStatus func(ws.Status)
 }
 
 func (b *BaseListener) SetupConn(conn *websocket.Conn) {
@@ -75,6 +83,7 @@ func (b *BaseListener) WSConfig() ws.Config {
 		MinBackoff: 1 * time.Second,
 		MaxBackoff: 15 * time.Second,
 		MaxRetries: 5,
+		OnStatus:   b.OnStatus,
 	}
 }
 

--- a/internal/webhook/event.go
+++ b/internal/webhook/event.go
@@ -1,0 +1,73 @@
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/AbacatePay/abacatepay-cli/internal/style"
+)
+
+// EventKind identifies what a listener Event represents.
+type EventKind int
+
+const (
+	// EventReceived is emitted for every webhook message read off the socket.
+	EventReceived EventKind = iota
+	// EventForwarded is emitted after an attempt to forward a webhook to the
+	// configured local URL.
+	EventForwarded
+	// EventInvalid is emitted when a socket message couldn't be parsed as JSON.
+	EventInvalid
+)
+
+// Event describes a single occurrence in a listener's lifecycle: a webhook
+// received from the relay, or the result of forwarding one to the user's
+// local server. Listeners report these through BaseListener.Emit, which
+// defaults to printing plain lines (today's behavior) when unset, and can be
+// overridden by a caller (e.g. the interactive `listen` dashboard) to route
+// events elsewhere instead.
+type Event struct {
+	Kind       EventKind
+	Time       time.Time
+	Name       string // webhook event type, e.g. "payment.completed"
+	ID         string
+	StatusCode int
+	StatusText string
+	RawJSON    string // syntax-highlighted body (via style.RenderJSON), only populated in verbose mode
+}
+
+// emit routes e through BaseListener.Emit if one is set, or falls back to
+// defaultEmit to preserve the plain-line output the CLI has always printed.
+func (b *BaseListener) emit(e Event) {
+	if b.Emit != nil {
+		b.Emit(e)
+		return
+	}
+	defaultEmit(e)
+}
+
+func defaultEmit(e Event) {
+	switch e.Kind {
+	case EventReceived:
+		style.LogWebhookReceived(e.Name, e.ID)
+		if e.RawJSON != "" {
+			fmt.Println(e.RawJSON)
+		}
+	case EventForwarded:
+		style.LogWebhookForwarded(e.StatusCode, e.StatusText, e.Name)
+	case EventInvalid:
+		style.PrintError("Received invalid JSON from WebSocket")
+	}
+}
+
+// prettyJSON returns a syntax-highlighted rendering of rawBody (matching
+// every other JSON the CLI prints, via style.RenderJSON), or "" when verbose
+// is false (the caller should skip showing the body at all in that case).
+func prettyJSON(verbose bool, rawBody []byte) string {
+	if !verbose {
+		return ""
+	}
+
+	return style.RenderJSON(json.RawMessage(rawBody))
+}

--- a/internal/webhook/listener.go
+++ b/internal/webhook/listener.go
@@ -1,7 +1,6 @@
 package webhook
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,7 +9,6 @@ import (
 	"time"
 
 	"github.com/AbacatePay/abacatepay-cli/internal/crypto"
-	"github.com/AbacatePay/abacatepay-cli/internal/style"
 	"github.com/AbacatePay/abacatepay-cli/internal/ws"
 
 	"github.com/gorilla/websocket"
@@ -70,7 +68,7 @@ func (l *Listener) readLoop(ctx context.Context, conn *websocket.Conn) error {
 		}
 
 		if err := json.Unmarshal(message, &raw); err != nil {
-			style.PrintError("Received invalid JSON from WebSocket")
+			l.emit(Event{Kind: EventInvalid, Time: time.Now()})
 			continue
 		}
 
@@ -85,8 +83,6 @@ func (l *Listener) readLoop(ctx context.Context, conn *websocket.Conn) error {
 }
 
 func (l *Listener) displayWebhook(meta webhookMetadata, rawBody []byte) {
-	style.LogWebhookReceived(meta.Event, meta.ID)
-
 	l.txLogger.Info("webhook_received",
 		"event", meta.Event,
 		"id", meta.ID,
@@ -95,16 +91,13 @@ func (l *Listener) displayWebhook(meta webhookMetadata, rawBody []byte) {
 		"raw_message", string(rawBody),
 	)
 
-	if !l.Cfg.Verbose {
-		return
-	}
-
-	var buf bytes.Buffer
-	if err := json.Indent(&buf, rawBody, "", "  "); err != nil {
-		fmt.Println(string(rawBody))
-		return
-	}
-	fmt.Println(buf.String())
+	l.emit(Event{
+		Kind:    EventReceived,
+		Time:    time.Now(),
+		Name:    meta.Event,
+		ID:      meta.ID,
+		RawJSON: prettyJSON(l.Cfg.Verbose, rawBody),
+	})
 }
 
 func (l *Listener) forward(ctx context.Context, message []byte, event string) error {
@@ -133,7 +126,13 @@ func (l *Listener) forward(ctx context.Context, message []byte, event string) er
 	}
 
 	statusCode := resp.StatusCode()
-	style.LogWebhookForwarded(statusCode, http.StatusText(statusCode), event)
+	l.emit(Event{
+		Kind:       EventForwarded,
+		Time:       time.Now(),
+		Name:       event,
+		StatusCode: statusCode,
+		StatusText: http.StatusText(statusCode),
+	})
 
 	if statusCode < 200 || statusCode >= 300 {
 		l.txLogger.Error("webhook_forward_error",

--- a/internal/webhook/tail.go
+++ b/internal/webhook/tail.go
@@ -1,14 +1,13 @@
 package webhook
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/AbacatePay/abacatepay-cli/internal/config"
-	"github.com/AbacatePay/abacatepay-cli/internal/style"
 	"github.com/AbacatePay/abacatepay-cli/internal/ws"
 
 	"github.com/gorilla/websocket"
@@ -71,7 +70,7 @@ func (t *TailListener) readLoop(ctx context.Context, conn *websocket.Conn) error
 		}
 
 		if err := json.Unmarshal(message, &raw); err != nil {
-			style.PrintError("Received invalid JSON from WebSocket")
+			t.emit(Event{Kind: EventInvalid, Time: time.Now()})
 			continue
 		}
 
@@ -80,16 +79,11 @@ func (t *TailListener) readLoop(ctx context.Context, conn *websocket.Conn) error
 }
 
 func (t *TailListener) displayWebhook(event, id string, rawBody []byte) {
-	style.LogWebhookReceived(event, id)
-
-	if !t.Cfg.Verbose {
-		return
-	}
-
-	var buf bytes.Buffer
-	if err := json.Indent(&buf, rawBody, "", "  "); err != nil {
-		fmt.Println(string(rawBody))
-		return
-	}
-	fmt.Println(buf.String())
+	t.emit(Event{
+		Kind:    EventReceived,
+		Time:    time.Now(),
+		Name:    event,
+		ID:      id,
+		RawJSON: prettyJSON(t.Cfg.Verbose, rawBody),
+	})
 }

--- a/internal/ws/connection.go
+++ b/internal/ws/connection.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/AbacatePay/abacatepay-cli/internal/clierr"
 	"github.com/AbacatePay/abacatepay-cli/internal/style"
 
 	"github.com/gorilla/websocket"
@@ -14,12 +15,32 @@ import (
 
 type Handler func(ctx context.Context, conn *websocket.Conn) error
 
+// Status describes a transition in the connection lifecycle, reported
+// through Config.OnStatus when set.
+type Status int
+
+const (
+	StatusConnecting Status = iota
+	StatusConnected
+	StatusRetrying
+)
+
 type Config struct {
 	URL        string
 	Headers    http.Header
 	MaxRetries int
 	MinBackoff time.Duration
 	MaxBackoff time.Duration
+
+	// OnStatus, if set, is called on every connection lifecycle transition.
+	// It must return quickly and must not block.
+	OnStatus func(Status)
+}
+
+func (cfg Config) reportStatus(s Status) {
+	if cfg.OnStatus != nil {
+		cfg.OnStatus(s)
+	}
 }
 
 func ConnectWithRetry(ctx context.Context, cfg Config, handler Handler) error {
@@ -34,6 +55,7 @@ func ConnectWithRetry(ctx context.Context, cfg Config, handler Handler) error {
 		}
 
 		slog.Debug("Connecting...", "url", cfg.URL)
+		cfg.reportStatus(StatusConnecting)
 
 		conn, _, err := websocket.DefaultDialer.DialContext(ctx, cfg.URL, cfg.Headers)
 		if err != nil {
@@ -42,7 +64,7 @@ func ConnectWithRetry(ctx context.Context, cfg Config, handler Handler) error {
 			if cfg.MaxRetries > 0 && retries >= cfg.MaxRetries {
 				errMsg := fmt.Sprintf("Failed to connect to %s after %d retries: %v", cfg.URL, retries, err)
 				style.PrintError(errMsg)
-				return fmt.Errorf("%s", errMsg)
+				return clierr.MarkDisplayed(fmt.Errorf("%s", errMsg))
 			}
 
 			slog.Warn(
@@ -51,6 +73,7 @@ func ConnectWithRetry(ctx context.Context, cfg Config, handler Handler) error {
 				"backoff", backoff,
 				"retry", fmt.Sprintf("%d/%d", retries, cfg.MaxRetries),
 			)
+			cfg.reportStatus(StatusRetrying)
 
 			select {
 			case <-ctx.Done():
@@ -65,6 +88,7 @@ func ConnectWithRetry(ctx context.Context, cfg Config, handler Handler) error {
 		}
 
 		slog.Info("WebSocket connected")
+		cfg.reportStatus(StatusConnected)
 		backoff = cfg.MinBackoff
 		retries = 0
 


### PR DESCRIPTION
## Summary

The CLI already lived in the Charm ecosystem (`huh` for forms, `lipgloss` for styling) but its dynamic/async output was inconsistent: a non-Charm spinner (`briandowns/spinner`), plain sequential prints in `listen`, raw `fmt.Printf` in `upgrade`, and no progress indication at all in `payments simulate`. This adopts `bubbletea`/`bubbles` (already indirect deps via `huh`) as the single rendering layer for that dynamic output, and fixes a couple of real bugs found along the way.

- **`internal/tui`**: a bubbletea spinner-to-result flow (`output.RunTask`) used by `login`, `logout`, `upgrade`, and `payments simulate` — the spinner's final frame *becomes* the result, one continuous render instead of a `bubbletea` animation followed by a separately-printed box (which, for `payments simulate`, actually raced the still-running spinner and corrupted output). Also a full interactive dashboard for `listen`: scrollable event feed, connection status, key bindings (`bubbles/viewport` + `key` + `help`). Both fall back to today's plain sequential-line output when stdout isn't a terminal or `-o` isn't `text`, so piped/scripted/CI use is unaffected.
- **`internal/webhook`**: listener display logic decoupled from the network loop via an optional `Emit` hook, so the interactive dashboard and the plain fallback share one source of truth instead of duplicating it.
- **`internal/logger`**: the console handler now only surfaces diagnostics under `--verbose`. Routine `Info`/`Warn` logs (`"Signed out"`, `"WebSocket connected"`, ...) were leaking as raw `level=INFO msg=...` text right next to the styled output — file logging is unaffected, `--verbose` still shows everything.
- **`internal/clierr`**: marks errors already displayed to the user (by `RunTask`, or by any handler that prints before returning) so the top-level command runner doesn't print them a second time. This was a real bug, not just cosmetic — `login`/`payments`/the websocket retry path could each show the same error box twice.
- Dropped the bordered box around success/error output for flat styled text, and standardized `upgrade` on English (it was the only command in Portuguese).
- Replaced `briandowns/spinner` with `bubbles/spinner`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] Verified live under a real pty: `upgrade` (spinner → result, single continuous render), `login` via both `--key` and the real device-flow path (confirmed the duplicate-error-box fix against a real 400 response), `logout`, `payments simulate` (including `--verbose` and `-o json`)
- [x] Confirmed non-interactive fallback (`| cat`) still produces plain sequential output for `listen`
- [ ] `listen`'s interactive dashboard against a real forwarded webhook (spinner/connection-status/event-feed rendering was verified via the same bubbletea primitives proven out in the `upgrade`/`login` pty tests, but not the full dashboard end-to-end with live traffic)
