### PR TITLE
fix: satisfy errcheck for type assertion in RunTask

### DIFF
--- a/internal/tui/task.go
+++ b/internal/tui/task.go
@@ -53,7 +53,12 @@ func RunTask(message string, fn func() (TaskResult, error)) error {
 		return runErr
 	}
 
-	return final.(taskModel).err
+	fm, ok := final.(taskModel)
+	if !ok {
+		return fmt.Errorf("unexpected tea model type %T", final)
+	}
+
+	return fm.err
 }
 
 type taskDoneMsg struct {


### PR DESCRIPTION
## Summary
- golangci-lint's errcheck was failing on `internal/tui/task.go:56` because `final.(taskModel)` is a single-value type assertion, which panics on failure and is flagged as an unchecked "error" return.
- Switched to the comma-ok form and return an explicit error if the assertion fails.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/tui/...`

https://claude.ai/code/session_01RTiUtjKLGMAdpKkMVeumxQ